### PR TITLE
Allow disabling logging to /tmp/hcidump.pklg file

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ BlueHeron.HCIDump.Logger
 This will produce a file `/tmp/hcidump.pklg` that can be loaded into Wireshark.
 
 **NOTE** This project configures logger so it is always enabled by default.
+However, this can be disabled by setting `config :blue_heron, log_hci_dump_file:
+false`
 
 The `BlueHeron.HCIDump.Logger` module implements a superset of Elixir's builtin logger and
 all non-HCI data is forwarded directly to Elixir's Logger.

--- a/lib/blue_heron/hci_dump/logger.ex
+++ b/lib/blue_heron/hci_dump/logger.ex
@@ -113,7 +113,9 @@ defmodule BlueHeron.HCIDump.Logger do
       pktlog = %PKTLOG{type: unquote(type), payload: unquote(payload)}
       encoded = HCIDump.encode(%PKTLOG{pktlog | tv_sec: ts, tv_us: usec}, unquote(direction))
 
-      _ = File.write("/tmp/hcidump.pklg", encoded, [:append])
+      if Application.get_env(:blue_heron, :log_hci_dump_file, true) do
+        _ = File.write("/tmp/hcidump.pklg", encoded, [:append])
+      end
 
       # metadata = [
       #   {:pktlog_direction, unquote(direction)},


### PR DESCRIPTION
On some systems the /tmp directory is limited in size, so it is nice to disable the logging to this file.

Fixes #58