### PR TITLE
Add some ATT commands required for GATT

### DIFF
--- a/lib/blue_heron/att.ex
+++ b/lib/blue_heron/att.ex
@@ -10,12 +10,20 @@ defmodule BlueHeron.ATT do
     ErrorResponse,
     ExchangeMTURequest,
     ExchangeMTUResponse,
+    FindInformationRequest,
+    FindInformationResponse,
+    ReadBlobRequest,
+    ReadBlobResponse,
     ReadByTypeRequest,
     ReadByTypeResponse,
     ReadByGroupTypeRequest,
     ReadByGroupTypeResponse,
+    ReadRequest,
+    ReadResponse,
     HandleValueNotification,
-    WriteCommand
+    WriteCommand,
+    WriteRequest,
+    WriteResponse
   }
 
   @doc "Takes binary data and returns a struct"
@@ -28,17 +36,41 @@ defmodule BlueHeron.ATT do
   def deserialize(base, <<0x03, _::binary>> = exchange_mtu_request),
     do: %{base | data: ExchangeMTUResponse.deserialize(exchange_mtu_request)}
 
+  def deserialize(base, <<0x04, _::binary>> = find_information_request),
+    do: %{base | data: FindInformationRequest.deserialize(find_information_request)}
+
+  def deserialize(base, <<0x05, _::binary>> = find_information_response),
+    do: %{base | data: FindInformationResponse.deserialize(find_information_response)}
+
   def deserialize(base, <<0x08, _::binary>> = exchange_mtu_request),
     do: %{base | data: ReadByTypeRequest.deserialize(exchange_mtu_request)}
 
   def deserialize(base, <<0x09, _::binary>> = exchange_mtu_request),
     do: %{base | data: ReadByTypeResponse.deserialize(exchange_mtu_request)}
 
+  def deserialize(base, <<0x0A, _::binary>> = read_request),
+    do: %{base | data: ReadRequest.deserialize(read_request)}
+
+  def deserialize(base, <<0x0B, _::binary>> = read_response),
+    do: %{base | data: ReadResponse.deserialize(read_response)}
+
+  def deserialize(base, <<0x0C, _::binary>> = read_blob_request),
+    do: %{base | data: ReadBlobRequest.deserialize(read_blob_request)}
+
+  def deserialize(base, <<0x0D, _::binary>> = read_blob_response),
+    do: %{base | data: ReadBlobResponse.deserialize(read_blob_response)}
+
   def deserialize(base, <<0x10, _::binary>> = read_by_group_type_request),
     do: %{base | data: ReadByGroupTypeRequest.deserialize(read_by_group_type_request)}
 
   def deserialize(base, <<0x11, _::binary>> = read_by_group_type_request),
     do: %{base | data: ReadByGroupTypeResponse.deserialize(read_by_group_type_request)}
+
+  def deserialize(base, <<0x12, _::binary>> = write_request),
+    do: %{base | data: WriteRequest.deserialize(write_request)}
+
+  def deserialize(base, <<0x13, _::binary>> = write_response),
+    do: %{base | data: WriteResponse.deserialize(write_response)}
 
   def deserialize(base, <<0x1B, _::binary>> = read_by_group_type_request),
     do: %{base | data: HandleValueNotification.deserialize(read_by_group_type_request)}

--- a/lib/blue_heron/att.ex
+++ b/lib/blue_heron/att.ex
@@ -12,6 +12,8 @@ defmodule BlueHeron.ATT do
     ExchangeMTUResponse,
     ExecuteWriteRequest,
     ExecuteWriteResponse,
+    FindByTypeValueRequest,
+    FindByTypeValueResponse,
     FindInformationRequest,
     FindInformationResponse,
     PrepareWriteRequest,
@@ -45,6 +47,12 @@ defmodule BlueHeron.ATT do
 
   def deserialize(base, <<0x05, _::binary>> = find_information_response),
     do: %{base | data: FindInformationResponse.deserialize(find_information_response)}
+
+  def deserialize(base, <<0x06, _::binary>> = find_by_type_value_request),
+    do: %{base | data: FindByTypeValueRequest.deserialize(find_by_type_value_request)}
+
+  def deserialize(base, <<0x07, _::binary>> = find_by_type_value_response),
+    do: %{base | data: FindByTypeValueResponse.deserialize(find_by_type_value_response)}
 
   def deserialize(base, <<0x08, _::binary>> = exchange_mtu_request),
     do: %{base | data: ReadByTypeRequest.deserialize(exchange_mtu_request)}

--- a/lib/blue_heron/att.ex
+++ b/lib/blue_heron/att.ex
@@ -16,6 +16,8 @@ defmodule BlueHeron.ATT do
     FindByTypeValueResponse,
     FindInformationRequest,
     FindInformationResponse,
+    HandleValueIndication,
+    HandleValueConfirmation,
     PrepareWriteRequest,
     PrepareWriteResponse,
     ReadBlobRequest,
@@ -98,6 +100,12 @@ defmodule BlueHeron.ATT do
 
   def deserialize(base, <<0x1B, _::binary>> = read_by_group_type_request),
     do: %{base | data: HandleValueNotification.deserialize(read_by_group_type_request)}
+
+  def deserialize(base, <<0x1D, _::binary>> = handle_value_indication),
+    do: %{base | data: HandleValueIndication.deserialize(handle_value_indication)}
+
+  def deserialize(base, <<0x1E, _::binary>> = handle_value_confirmation),
+    do: %{base | data: HandleValueConfirmation.deserialize(handle_value_confirmation)}
 
   def deserialize(base, <<0x52, _::binary>> = read_by_group_type_request),
     do: %{base | data: WriteCommand.deserialize(read_by_group_type_request)}

--- a/lib/blue_heron/att.ex
+++ b/lib/blue_heron/att.ex
@@ -10,8 +10,12 @@ defmodule BlueHeron.ATT do
     ErrorResponse,
     ExchangeMTURequest,
     ExchangeMTUResponse,
+    ExecuteWriteRequest,
+    ExecuteWriteResponse,
     FindInformationRequest,
     FindInformationResponse,
+    PrepareWriteRequest,
+    PrepareWriteResponse,
     ReadBlobRequest,
     ReadBlobResponse,
     ReadByTypeRequest,
@@ -71,6 +75,18 @@ defmodule BlueHeron.ATT do
 
   def deserialize(base, <<0x13, _::binary>> = write_response),
     do: %{base | data: WriteResponse.deserialize(write_response)}
+
+  def deserialize(base, <<0x16, _::binary>> = prepare_write_request),
+    do: %{base | data: PrepareWriteRequest.deserialize(prepare_write_request)}
+
+  def deserialize(base, <<0x17, _::binary>> = prepare_write_response),
+    do: %{base | data: PrepareWriteResponse.deserialize(prepare_write_response)}
+
+  def deserialize(base, <<0x18, _::binary>> = execute_write_request),
+    do: %{base | data: ExecuteWriteRequest.deserialize(execute_write_request)}
+
+  def deserialize(base, <<0x19, _::binary>> = execute_write_response),
+    do: %{base | data: ExecuteWriteResponse.deserialize(execute_write_response)}
 
   def deserialize(base, <<0x1B, _::binary>> = read_by_group_type_request),
     do: %{base | data: HandleValueNotification.deserialize(read_by_group_type_request)}

--- a/lib/blue_heron/att/confirmations/handle_value_confirmation.ex
+++ b/lib/blue_heron/att/confirmations/handle_value_confirmation.ex
@@ -1,0 +1,11 @@
+defmodule BlueHeron.ATT.HandleValueConfirmation do
+  defstruct [:opcode]
+
+  def serialize(%{}) do
+    <<0x1E>>
+  end
+
+  def deserialize(<<0x1E>>) do
+    %__MODULE__{opcode: 0x1E}
+  end
+end

--- a/lib/blue_heron/att/indications/handle_value_indication.ex
+++ b/lib/blue_heron/att/indications/handle_value_indication.ex
@@ -1,0 +1,15 @@
+defmodule BlueHeron.ATT.HandleValueIndication do
+  defstruct [:opcode, :handle, :value]
+
+  def serialize(%{handle: handle, value: value}) do
+    <<0x1D, handle::little-16, value::binary>>
+  end
+
+  def deserialize(<<0x1D, handle::little-16, value::binary>>) do
+    %__MODULE__{
+      opcode: 0x1D,
+      handle: handle,
+      value: value
+    }
+  end
+end

--- a/lib/blue_heron/att/requests/execute_write_request.ex
+++ b/lib/blue_heron/att/requests/execute_write_request.ex
@@ -1,0 +1,11 @@
+defmodule BlueHeron.ATT.ExecuteWriteRequest do
+  defstruct [:opcode, :flags]
+
+  def serialize(%{flags: flags}) do
+    <<0x18, flags>>
+  end
+
+  def deserialize(<<0x18, flags>>) do
+    %__MODULE__{opcode: 0x18, flags: flags}
+  end
+end

--- a/lib/blue_heron/att/requests/find_by_type_value_request.ex
+++ b/lib/blue_heron/att/requests/find_by_type_value_request.ex
@@ -1,0 +1,26 @@
+defmodule BlueHeron.ATT.FindByTypeValueRequest do
+  defstruct [:opcode, :starting_handle, :ending_handle, :attribute_type, :attribute_value]
+
+  def serialize(%{
+        starting_handle: starting_handle,
+        ending_handle: ending_handle,
+        attribute_type: attribute_type,
+        attribute_value: attribute_value
+      }) do
+    <<0x06, starting_handle::little-16, ending_handle::little-16, attribute_type::little-16,
+      attribute_value::binary>>
+  end
+
+  def deserialize(
+        <<0x06, starting_handle::little-16, ending_handle::little-16, attribute_type::little-16,
+          attribute_value::binary>>
+      ) do
+    %__MODULE__{
+      opcode: 0x06,
+      starting_handle: starting_handle,
+      ending_handle: ending_handle,
+      attribute_type: attribute_type,
+      attribute_value: attribute_value
+    }
+  end
+end

--- a/lib/blue_heron/att/requests/find_information_request.ex
+++ b/lib/blue_heron/att/requests/find_information_request.ex
@@ -1,0 +1,11 @@
+defmodule BlueHeron.ATT.FindInformationRequest do
+  defstruct [:opcode, :starting_handle, :ending_handle]
+
+  def serialize(%{starting_handle: starting_handle, ending_handle: ending_handle}) do
+    <<0x04, starting_handle::little-16, ending_handle::little-16>>
+  end
+
+  def deserialize(<<0x04, starting_handle::little-16, ending_handle::little-16>>) do
+    %__MODULE__{opcode: 0x04, starting_handle: starting_handle, ending_handle: ending_handle}
+  end
+end

--- a/lib/blue_heron/att/requests/prepare_write_request.ex
+++ b/lib/blue_heron/att/requests/prepare_write_request.ex
@@ -1,0 +1,11 @@
+defmodule BlueHeron.ATT.PrepareWriteRequest do
+  defstruct [:opcode, :handle, :offset, :value]
+
+  def serialize(%{handle: handle, offset: offset, value: value}) do
+    <<0x16, handle::little-16, offset::little-16, value::binary>>
+  end
+
+  def deserialize(<<0x16, handle::little-16, offset::little-16, value::binary>>) do
+    %__MODULE__{opcode: 0x16, handle: handle, offset: offset, value: value}
+  end
+end

--- a/lib/blue_heron/att/requests/read_blob_request.ex
+++ b/lib/blue_heron/att/requests/read_blob_request.ex
@@ -1,0 +1,15 @@
+defmodule BlueHeron.ATT.ReadBlobRequest do
+  defstruct [:opcode, :handle, :offset]
+
+  def serialize(%{handle: handle, offset: offset}) do
+    <<0x0C, handle::little-16, offset::little-16>>
+  end
+
+  def deserialize(<<0x0C, handle::little-16, offset::little-16>>) do
+    %__MODULE__{
+      opcode: 0x0C,
+      handle: handle,
+      offset: offset
+    }
+  end
+end

--- a/lib/blue_heron/att/requests/read_request.ex
+++ b/lib/blue_heron/att/requests/read_request.ex
@@ -1,0 +1,11 @@
+defmodule BlueHeron.ATT.ReadRequest do
+  defstruct [:opcode, :handle]
+
+  def serialize(%{handle: handle}) do
+    <<0x0A, handle::little-16>>
+  end
+
+  def deserialize(<<0x0A, handle::little-16>>) do
+    %__MODULE__{opcode: 0x0A, handle: handle}
+  end
+end

--- a/lib/blue_heron/att/requests/write_request.ex
+++ b/lib/blue_heron/att/requests/write_request.ex
@@ -1,0 +1,11 @@
+defmodule BlueHeron.ATT.WriteRequest do
+  defstruct [:opcode, :handle, :value]
+
+  def serialize(%{handle: handle, value: value}) do
+    <<0x12, handle::little-16, value::binary>>
+  end
+
+  def deserialize(<<0x12, handle::little-16, value::binary>>) do
+    %__MODULE__{opcode: 0x12, handle: handle, value: value}
+  end
+end

--- a/lib/blue_heron/att/responses/execute_write_response.ex
+++ b/lib/blue_heron/att/responses/execute_write_response.ex
@@ -1,0 +1,11 @@
+defmodule BlueHeron.ATT.ExecuteWriteResponse do
+  defstruct [:opcode]
+
+  def serialize(%{}) do
+    <<0x19>>
+  end
+
+  def deserialize(<<0x19>>) do
+    %__MODULE__{opcode: 0x19}
+  end
+end

--- a/lib/blue_heron/att/responses/find_by_type_value_response.ex
+++ b/lib/blue_heron/att/responses/find_by_type_value_response.ex
@@ -1,0 +1,39 @@
+defmodule BlueHeron.ATT.FindByTypeValueResponse do
+  defstruct [:opcode, :handles_information_list]
+
+  defmodule HandlesInformation do
+    defstruct [:found_attribute_handle, :group_end_handle]
+
+    def serialize(%{
+          found_attribute_handle: found_attribute_handle,
+          group_end_handle: group_end_handle
+        }) do
+      <<found_attribute_handle::little-16, group_end_handle::little-16>>
+    end
+
+    def deserialize(<<found_attribute_handle::little-16, group_end_handle::little-16>>) do
+      %__MODULE__{
+        found_attribute_handle: found_attribute_handle,
+        group_end_handle: group_end_handle
+      }
+    end
+  end
+
+  def serialize(%{handles_information_list: handles_information_list}) do
+    handles_information_list =
+      handles_information_list
+      |> Enum.map(fn handles_info -> HandlesInformation.serialize(handles_info) end)
+      |> IO.iodata_to_binary()
+
+    <<0x07, handles_information_list::binary>>
+  end
+
+  def deserialize(<<0x07, handles_information_list::binary>>) do
+    handles_information_list =
+      for <<handles_info::binary-4 <- handles_information_list>> do
+        HandlesInformation.deserialize(handles_info)
+      end
+
+    %__MODULE__{opcode: 0x07, handles_information_list: handles_information_list}
+  end
+end

--- a/lib/blue_heron/att/responses/find_information_response.ex
+++ b/lib/blue_heron/att/responses/find_information_response.ex
@@ -1,0 +1,62 @@
+defmodule BlueHeron.ATT.FindInformationResponse do
+  defstruct [:opcode, :format, :information_data]
+
+  defmodule InformationData do
+    defstruct [:handle, :uuid]
+
+    def serialize(%{handle: handle, uuid: uuid}) when uuid > 65535 do
+      <<handle::little-16, uuid::little-128>>
+    end
+
+    def serialize(%{handle: handle, uuid: uuid}) do
+      <<handle::little-16, uuid::little-16>>
+    end
+
+    def deserialize(<<handle::little-16, uuid::little-128>>) do
+      %__MODULE__{handle: handle, uuid: uuid}
+    end
+
+    def deserialize(<<handle::little-16, uuid::little-16>>) do
+      %__MODULE__{handle: handle, uuid: uuid}
+    end
+  end
+
+  def serialize(%{format: format, information_data: information_data}) do
+    information_data =
+      for data <- information_data, into: <<>> do
+        InformationData.serialize(data)
+      end
+
+    <<0x05, format, information_data::binary>>
+  end
+
+  def deserialize(<<0x05, format, information_data::binary>>) do
+    pair_size =
+      case format do
+        # 0x01 means pairs of 2 byte UUIDs
+        0x01 -> 4
+        # 0x02 means pairs of 16 byte UUIDs
+        0x02 -> 18
+      end
+
+    information_data = chunk_information_data(pair_size, information_data)
+
+    %__MODULE__{
+      opcode: 0x05,
+      format: format,
+      information_data: information_data
+    }
+  end
+
+  defp chunk_information_data(size, data, acc \\ [])
+
+  defp chunk_information_data(_size, <<>>, acc) do
+    Enum.reverse(acc)
+  end
+
+  defp chunk_information_data(pair_size, data, acc) do
+    <<chunk::binary-size(pair_size), rest::binary>> = data
+    acc = [InformationData.deserialize(chunk) | acc]
+    chunk_information_data(pair_size, rest, acc)
+  end
+end

--- a/lib/blue_heron/att/responses/prepare_write_response.ex
+++ b/lib/blue_heron/att/responses/prepare_write_response.ex
@@ -1,0 +1,11 @@
+defmodule BlueHeron.ATT.PrepareWriteResponse do
+  defstruct [:opcode, :handle, :offset, :value]
+
+  def serialize(%{handle: handle, offset: offset, value: value}) do
+    <<0x17, handle::little-16, offset::little-16, value::binary>>
+  end
+
+  def deserialize(<<0x17, handle::little-16, offset::little-16, value::binary>>) do
+    %__MODULE__{opcode: 0x17, handle: handle, offset: offset, value: value}
+  end
+end

--- a/lib/blue_heron/att/responses/read_blob_response.ex
+++ b/lib/blue_heron/att/responses/read_blob_response.ex
@@ -1,0 +1,11 @@
+defmodule BlueHeron.ATT.ReadBlobResponse do
+  defstruct [:opcode, :value]
+
+  def serialize(%{value: value}) do
+    <<0x0D, value::binary>>
+  end
+
+  def deserialize(<<0x0D, value::binary>>) do
+    %__MODULE__{opcode: 0x0D, value: value}
+  end
+end

--- a/lib/blue_heron/att/responses/read_response.ex
+++ b/lib/blue_heron/att/responses/read_response.ex
@@ -1,0 +1,11 @@
+defmodule BlueHeron.ATT.ReadResponse do
+  defstruct [:opcode, :value]
+
+  def serialize(%{value: value}) do
+    <<0x0B, value::binary>>
+  end
+
+  def deserialize(<<0x0B, value::binary>>) do
+    %__MODULE__{opcode: 0x0B, value: value}
+  end
+end

--- a/lib/blue_heron/att/responses/write_response.ex
+++ b/lib/blue_heron/att/responses/write_response.ex
@@ -1,0 +1,11 @@
+defmodule BlueHeron.ATT.WriteResponse do
+  defstruct [:opcode]
+
+  def serialize(%{}) do
+    <<0x13>>
+  end
+
+  def deserialize(<<0x13>>) do
+    %__MODULE__{opcode: 0x13}
+  end
+end


### PR DESCRIPTION
This adds:

- FindInformationRequest and FindInformationResponse (used in CHARACTERISTIC DESCRIPTOR DISCOVERY procedure)
- ReadRequest, ReadResponse, ReadBlobRequest and ReadBlobResponse (used in CHARACTERISTIC VALUE READ procedure)
- WriteRequest, WriteResponse, PrepareWriteRequest, PrepareWriteResponse, ExecuteWriteRequest and ExecuteWriteResponse  (used in CHARACTERISTIC VALUE WRITE procedure).
- HandleValueIndication and HandleValueConfirmation (used in CHARACTERISTIC VALUE INDICATION procedure)
- FindByTypeValueRequest and FindByTypeValueResponse (used in PRIMARY SERVICE DISCOVERY procedure)

With this, all ATT commands used for GATT should be available in Blue Heron.

I have not added any tests for these, mainly out of laziness 😈 . I have tested half of them on a real device. Let me know if you want more tests 😃

Note that there's a bit of footgun here. Whatever the ATT request/response contains, it must not be larger than the ATT_MTU (which by default is 23 bytes). I'm not sure how this would be handled best? For now the solution is to let the user worry about it, which works for my use case, but should probably be fixed eventually.