### PR TITLE
Add peripheral

### DIFF
--- a/lib/blue_heron/acl.ex
+++ b/lib/blue_heron/acl.ex
@@ -4,9 +4,12 @@ defmodule BlueHeron.ACL do
   defstruct [:handle, :flags, :data]
 
   def deserialize(
-        <<handle::little-12, pb::2, bc::2, length::little-16, acl_data::binary-size(length)>>
+        <<lower_handle, pb::2, bc::2, upper_handle::4, length::little-16,
+          acl_data::binary-size(length)>>
       ) do
     data = BlueHeron.L2Cap.deserialize(acl_data)
+
+    <<handle::little-12>> = <<lower_handle, upper_handle::4>>
 
     %ACL{
       handle: handle,
@@ -21,7 +24,8 @@ defmodule BlueHeron.ACL do
 
   def serialize(%ACL{data: data, handle: handle, flags: %{pb: pb, bc: bc}}) do
     length = byte_size(data)
-    <<handle::little-12, pb::2, bc::2, length::little-16, data::binary-size(length)>>
+    <<lower_handle, upper_handle::4>> = <<handle::little-12>>
+    <<lower_handle, pb::2, bc::2, upper_handle::4, length::little-16, data::binary-size(length)>>
   end
 
   def serialize(binary) when is_binary(binary), do: binary

--- a/lib/blue_heron/gatt/characteristic.ex
+++ b/lib/blue_heron/gatt/characteristic.ex
@@ -1,0 +1,12 @@
+defmodule BlueHeron.GATT.Characteristic do
+  defstruct [:id, :type, :properties, :handle, :value_handle]
+
+  # id is required, can be any term, but must be unique within the services() function
+  # type is required, must be either 16 or 128 bit UUID
+  # properties is required, must be an integer between 0 and 255
+  # handle and value_handle should not be specified by the user
+  def new(args) do
+    args = Map.take(args, [:id, :type, :properties])
+    struct!(__MODULE__, args)
+  end
+end

--- a/lib/blue_heron/gatt/server.ex
+++ b/lib/blue_heron/gatt/server.ex
@@ -1,0 +1,331 @@
+defmodule BlueHeron.GATT.Server do
+  alias BlueHeron.ATT.{
+    ErrorResponse,
+    FindInformationRequest,
+    PrepareWriteRequest,
+    PrepareWriteResponse,
+    ExecuteWriteRequest,
+    ExecuteWriteResponse,
+    ReadBlobRequest,
+    ReadBlobResponse,
+    ReadByGroupTypeRequest,
+    ReadByGroupTypeResponse,
+    ReadByTypeRequest,
+    ReadByTypeResponse,
+    ReadRequest,
+    ReadResponse,
+    WriteRequest,
+    WriteResponse
+  }
+
+  alias BlueHeron.GATT.Service
+
+  @callback profile() :: [Service.t()]
+  @callback read(any()) :: {:ok, binary()} | {:error, term()}
+  @callback write(any(), binary()) :: :ok | {:error, term()}
+
+  defstruct [:mod, :profile, :mtu, :write_handle, :write_buffer]
+
+  @discover_all_primary_services 0x2800
+  @find_included_services 0x2802
+  @discover_all_characteristics 0x2803
+
+  def init(mod) do
+    profile = hydrate(mod.profile())
+
+    %__MODULE__{
+      mod: mod,
+      profile: profile,
+      mtu: 23,
+      write_handle: nil,
+      write_buffer: ""
+    }
+  end
+
+  def handle(state, request) do
+    case request do
+      %ReadByGroupTypeRequest{uuid: @discover_all_primary_services} ->
+        discover_all_primary_services(state, request)
+
+      %ReadByTypeRequest{uuid: @find_included_services} ->
+        find_included_services(state, request)
+
+      %ReadByTypeRequest{uuid: @discover_all_characteristics} ->
+        discover_all_characteristics(state, request)
+
+      %FindInformationRequest{} ->
+        discover_all_characteristic_descriptors(state, request)
+
+      %ReadRequest{} ->
+        read_characteristic_value(state, request)
+
+      %ReadBlobRequest{} ->
+        read_long_characteristic_value(state, request)
+
+      %WriteRequest{} ->
+        write_characteristic_value(state, request)
+
+      %PrepareWriteRequest{} ->
+        write_long_characteristic_value(state, request)
+
+      %ExecuteWriteRequest{} ->
+        write_long_characteristic_value(state, request)
+    end
+  end
+
+  def discover_all_primary_services(state, request) do
+    services =
+      Enum.filter(state.profile, fn service ->
+        service.primary? and service.handle >= request.starting_handle and
+          service.handle <= request.ending_handle
+      end)
+
+    case services do
+      [] ->
+        {state,
+         %ErrorResponse{
+           handle: request.starting_handle,
+           request_opcode: request.opcode,
+           error: :attribute_not_found
+         }}
+
+      services_in_range ->
+        attribute_data =
+          services_in_range
+          |> Enum.map(fn service ->
+            %ReadByGroupTypeResponse.AttributeData{
+              handle: service.handle,
+              end_group_handle: service.end_group_handle,
+              uuid: service.type
+            }
+          end)
+          |> filter_by_uuid_size()
+          |> limit_attribute_count(state.mtu)
+
+        {state, %ReadByGroupTypeResponse{attribute_data: attribute_data}}
+    end
+  end
+
+  def find_included_services(state, request) do
+    services =
+      Enum.filter(state.profile, fn service ->
+        not service.primary? and service.handle >= request.starting_handle and
+          service.handle <= request.ending_handle
+      end)
+
+    case services do
+      [] ->
+        {state,
+         %ErrorResponse{
+           handle: request.starting_handle,
+           request_opcode: request.opcode,
+           error: :attribute_not_found
+         }}
+
+      services_in_range ->
+        attribute_data =
+          services_in_range
+          |> Enum.map(fn service ->
+            %ReadByGroupTypeResponse.AttributeData{
+              handle: service.handle,
+              end_group_handle: service.end_group_handle,
+              uuid: service.type
+            }
+          end)
+          |> filter_by_uuid_size()
+          |> limit_attribute_count(state.mtu)
+
+        {state, %ReadByGroupTypeResponse{attribute_data: attribute_data}}
+    end
+  end
+
+  def discover_all_characteristics(state, request) do
+    characteristics =
+      state.profile
+      |> Enum.flat_map(fn service -> service.characteristics end)
+      |> Enum.filter(fn characteristic ->
+        characteristic.handle >= request.starting_handle and
+          characteristic.handle <= request.ending_handle
+      end)
+
+    case characteristics do
+      [] ->
+        {state,
+         %ErrorResponse{
+           handle: request.starting_handle,
+           request_opcode: request.opcode,
+           error: :attribute_not_found
+         }}
+
+      characteristics_in_range ->
+        attribute_data =
+          characteristics_in_range
+          |> Enum.map(fn characteristic ->
+            %ReadByTypeResponse.AttributeData{
+              handle: characteristic.handle,
+              uuid: characteristic.type,
+              characteristic_properties: characteristic.properties,
+              characteristic_value_handle: characteristic.value_handle
+            }
+          end)
+          |> filter_by_uuid_size()
+          |> limit_attribute_count(state.mtu)
+
+        {state, %ReadByTypeResponse{attribute_data: attribute_data}}
+    end
+  end
+
+  def discover_all_characteristic_descriptors(state, request) do
+    # TODO: Implement
+    {state,
+     %ErrorResponse{
+       handle: request.starting_handle,
+       request_opcode: request.opcode,
+       error: :attribute_not_found
+     }}
+  end
+
+  def read_characteristic_value(state, request) do
+    id = find_characteristic_id(state.profile, request.handle)
+    {:ok, value} = state.mod.read(id)
+
+    # TODO: Might want to cache the value if it's longer than MTU - 1, and then
+    # serve the read_long_characteristic_value requests from that cache
+    # in order to avoid inconsistent reads if the value is updated during the read operation.
+    value =
+      if byte_size(value) > state.mtu - 1 do
+        :binary.part(value, 0, state.mtu - 1)
+      else
+        value
+      end
+
+    {state, %ReadResponse{value: value}}
+  end
+
+  def read_long_characteristic_value(state, request) do
+    id = find_characteristic_id(state.profile, request.handle)
+    {:ok, value} = state.mod.read(id)
+
+    value =
+      if byte_size(value) - request.offset > state.mtu - 1 do
+        :binary.part(value, request.offset, state.mtu - 1)
+      else
+        :binary.part(value, request.offset, byte_size(value) - request.offset)
+      end
+
+    {state, %ReadBlobResponse{value: value}}
+  end
+
+  def write_characteristic_value(state, request) do
+    id = find_characteristic_id(state.profile, request.handle)
+    :ok = state.mod.write(id, request.value)
+
+    {state, %WriteResponse{}}
+  end
+
+  def write_long_characteristic_value(state, %PrepareWriteRequest{} = request) do
+    # TODO: Probably want to store a list of write-operations and only materialize the resulting binary
+    # when receiving the ExecuteWriteRequest - in case the PrepareWriteRequest do not arrive in order.
+    state = %{
+      state
+      | write_handle: request.handle,
+        write_buffer: state.write_buffer <> request.value
+    }
+
+    {state,
+     %PrepareWriteResponse{
+       handle: request.handle,
+       offset: request.offset,
+       value: request.value
+     }}
+  end
+
+  def write_long_characteristic_value(state, %ExecuteWriteRequest{flags: 1}) do
+    id = find_characteristic_id(state.profile, state.write_handle)
+    :ok = state.mod.write(id, state.write_buffer)
+    state = %{state | write_handle: nil, write_buffer: ""}
+
+    {state, %ExecuteWriteResponse{}}
+  end
+
+  def write_long_characteristic_value(state, %ExecuteWriteRequest{flags: 0}) do
+    state = %{state | write_handle: nil, write_buffer: ""}
+
+    {state, %ExecuteWriteResponse{}}
+  end
+
+  defp hydrate(profile) do
+    # To each service, assign a handle and end handle
+    # assign handle to characteristics as well
+    # Maybe also create a characteristic.value_handle => characteristic.id
+    # TODO: Check that ID's are unique
+    # TODO: Check the services with primary?: false are included in other services
+    {_next_handle, profile} =
+      Enum.reduce(profile, {1, []}, fn service, {next_handle, acc} ->
+        service_handle = next_handle
+
+        {next_handle, characteristics} =
+          assign_characteristic_handles(service.characteristics, next_handle + 1)
+
+        service = %{
+          service
+          | handle: service_handle,
+            end_group_handle: next_handle - 1,
+            characteristics: characteristics
+        }
+
+        {next_handle, [service | acc]}
+      end)
+
+    Enum.reverse(profile)
+  end
+
+  defp assign_characteristic_handles(characteristics, starting_handle) do
+    {next_handle, characteristics} =
+      Enum.reduce(characteristics, {starting_handle, []}, fn characteristic, {next_handle, acc} ->
+        characteristic = %{characteristic | handle: next_handle, value_handle: next_handle + 1}
+        {next_handle + 2, [characteristic | acc]}
+      end)
+
+    {next_handle, Enum.reverse(characteristics)}
+  end
+
+  # Lists of attributes must only contain attributes whose UUID size
+  # is the same as the first attribute in the list
+  defp filter_by_uuid_size([attr | _] = attributes) do
+    target_size = uuid_byte_size(attr.uuid)
+    Enum.take_while(attributes, fn attr -> uuid_byte_size(attr.uuid) == target_size end)
+  end
+
+  # The serialized size of the response is not allowed to exceed the MTU
+  # The serialized size can be calculated as size = overhead + length(attributes) * bytes_per_attribute
+  defp limit_attribute_count(attributes, mtu) do
+    {bytes_per_attribute, overhead} =
+      case hd(attributes) do
+        %ReadByGroupTypeResponse.AttributeData{} = attr ->
+          {4 + uuid_byte_size(attr.uuid), 2}
+
+        %ReadByTypeResponse.AttributeData{} = attr ->
+          {5 + uuid_byte_size(attr.uuid), 2}
+      end
+
+    max_attribute_count = trunc((mtu - overhead) / bytes_per_attribute)
+
+    Enum.take(attributes, max_attribute_count)
+  end
+
+  defp uuid_byte_size(uuid) do
+    case uuid <= 0xFFFF do
+      true -> 2
+      false -> 16
+    end
+  end
+
+  defp find_characteristic_id(profile, characteristic_value_handle) do
+    profile
+    |> Enum.flat_map(fn service -> service.characteristics end)
+    |> Enum.find_value(fn characteristic ->
+      if characteristic.value_handle == characteristic_value_handle, do: characteristic.id
+    end)
+  end
+end

--- a/lib/blue_heron/gatt/service.ex
+++ b/lib/blue_heron/gatt/service.ex
@@ -1,0 +1,26 @@
+defmodule BlueHeron.GATT.Service do
+  @type t() :: map()
+
+  defstruct [
+    :id,
+    :primary?,
+    :type,
+    :included_services,
+    :characteristics,
+    :handle,
+    :end_group_handle
+  ]
+
+  # id is required, can be any term, but must be unique within the services() function
+  # primary? defaults to true, set it to false if it should only show up as an included service
+  # type is required, must be either 16 or 128 bit UUID
+  # included_services is a list of service ID's to be included in the definition of this service
+  # characteristics is a list of characteristics
+  def new(args) do
+    args =
+      Map.put_new(args, :primary?, true)
+      |> Map.take([:id, :primary?, :type, :included_services, :characteristics])
+
+    struct!(__MODULE__, args)
+  end
+end

--- a/lib/peripheral.ex
+++ b/lib/peripheral.ex
@@ -1,0 +1,136 @@
+defmodule BlueHeron.Peripheral do
+  alias BlueHeron.HCI.Command.LEController.{
+    SetAdvertisingParameters,
+    SetAdvertisingData,
+    SetAdvertisingEnable
+  }
+
+  alias BlueHeron.HCI.Event.{CommandComplete, DisconnectionComplete}
+  alias BlueHeron.HCI.Event.LEMeta.ConnectionComplete
+
+  alias BlueHeron.{ACL, L2Cap}
+
+  alias BlueHeron.GATT
+
+  @behaviour :gen_statem
+
+  defstruct [:ctx, :controlling_process, :conn_handle, :gatt_server]
+
+  def start_link(context, gatt_server) do
+    :gen_statem.start_link(__MODULE__, [context, gatt_server, self()], [])
+  end
+
+  def set_advertising_parameters(pid, params) do
+    :gen_statem.call(pid, {:set_parameters, params})
+  end
+
+  def set_advertising_data(pid, data) do
+    :gen_statem.call(pid, {:set_advertising_data, data})
+  end
+
+  def start_advertising(pid) do
+    :gen_statem.call(pid, :start_advertising)
+  end
+
+  def stop_advertising(pid) do
+    :gen_statem.call(pid, :stop_advertising)
+  end
+
+  @impl :gen_statem
+  def callback_mode(), do: :state_functions
+
+  @impl :gen_statem
+  def init([ctx, gatt_handler, controlling_process]) do
+    :ok = BlueHeron.add_event_handler(ctx)
+    gatt_server = GATT.Server.init(gatt_handler)
+
+    data = %__MODULE__{
+      controlling_process: controlling_process,
+      ctx: ctx,
+      conn_handle: nil,
+      gatt_server: gatt_server
+    }
+
+    {:ok, :wait_working, data, []}
+  end
+
+  def wait_working(:info, {:BLUETOOTH_EVENT_STATE, :HCI_STATE_WORKING}, data) do
+    {:next_state, :ready, data}
+  end
+
+  def wait_working(:info, {:HCI_EVENT_PACKET, _}, _data) do
+    :keep_state_and_data
+  end
+
+  def wait_working({:call, _from}, _call, _data), do: {:keep_state_and_data, [:postpone]}
+
+  def ready({:call, from}, {:set_parameters, params}, data) do
+    command = SetAdvertisingParameters.new(params)
+
+    {:ok, %CommandComplete{return_parameters: %{status: 0}}} =
+      BlueHeron.hci_command(data.ctx, command)
+
+    {:keep_state_and_data, [{:reply, from, :ok}]}
+  end
+
+  def ready({:call, from}, {:set_advertising_data, adv_data}, data) do
+    command = SetAdvertisingData.new(advertising_data: adv_data)
+
+    {:ok, %CommandComplete{return_parameters: %{status: 0}}} =
+      BlueHeron.hci_command(data.ctx, command)
+
+    {:keep_state_and_data, [{:reply, from, :ok}]}
+  end
+
+  def ready({:call, from}, :start_advertising, data) do
+    command = SetAdvertisingEnable.new(advertising_enable: true)
+
+    {:ok, %CommandComplete{return_parameters: %{status: 0}}} =
+      BlueHeron.hci_command(data.ctx, command)
+
+    {:next_state, :advertising, data, [{:reply, from, :ok}]}
+  end
+
+  def ready(:info, {:HCI_EVENT_PACKET, _event}, _data) do
+    :keep_state_and_data
+  end
+
+  def advertising({:call, from}, :stop_advertising, data) do
+    command = SetAdvertisingEnable.new(advertising_enable: false)
+
+    {:ok, %CommandComplete{return_parameters: %{status: 0}}} =
+      BlueHeron.hci_command(data.ctx, command)
+
+    {:next_state, :ready, data, [{:reply, from, :ok}]}
+  end
+
+  def advertising(:info, {:HCI_EVENT_PACKET, %ConnectionComplete{} = event}, data) do
+    {:next_state, :connected, %{data | conn_handle: event.connection_handle}, []}
+  end
+
+  def advertising(:info, {:HCI_EVENT_PACKET, _event}, _data) do
+    # TODO: Handle scan request, and maybe other events as well
+    :keep_state_and_data
+  end
+
+  def connected(:info, {:HCI_ACL_DATA_PACKET, %ACL{data: %L2Cap{data: request}}}, data) do
+    {gatt_server, response} = GATT.Server.handle(data.gatt_server, request)
+
+    acl_response = %ACL{
+      handle: data.conn_handle,
+      flags: %{bc: 0, pb: 0},
+      data: %L2Cap{
+        cid: 0x04,
+        data: response
+      }
+    }
+
+    BlueHeron.acl(data.ctx, acl_response)
+
+    {:keep_state, %{data | gatt_server: gatt_server}, []}
+  end
+
+  def connected(:info, {:HCI_EVENT_PACKET, %DisconnectionComplete{}}, data) do
+    {:next_state, :ready, data}
+  end
+end

--- a/test/blue_heron/acl_test.exs
+++ b/test/blue_heron/acl_test.exs
@@ -1,0 +1,37 @@
+defmodule BlueHeron.ACLTest do
+  use ExUnit.Case
+
+  alias BlueHeron.{ACL, ATT, L2Cap}
+
+  test "encodes packet correctly" do
+    serialized =
+      %ACL{
+        data: %L2Cap{
+          cid: 4,
+          data: %ATT.ExchangeMTURequest{client_rx_mtu: 185, opcode: 2}
+        },
+        flags: %{bc: 2, pb: 0},
+        handle: 64
+      }
+      |> ACL.serialize()
+
+    assert <<64, 32, 7, 0, 3, 0, 4, 0, 2, 185, 0>> == serialized
+  end
+
+  test "serde is symmetric" do
+    handle = Enum.random(0x001..0xEFF)
+    pb = Enum.random(0b00..0b11)
+    bc = Enum.random(0b00..0b11)
+
+    expected = %ACL{
+      flags: %{bc: bc, pb: pb},
+      handle: handle,
+      data: %L2Cap{
+        cid: 4,
+        data: %ATT.ExchangeMTURequest{client_rx_mtu: 185, opcode: 2}
+      }
+    }
+
+    assert expected == expected |> ACL.serialize() |> ACL.deserialize()
+  end
+end

--- a/test/blue_heron/gatt/server_test.exs
+++ b/test/blue_heron/gatt/server_test.exs
@@ -1,0 +1,353 @@
+defmodule BlueHeron.GATT.ServerTest do
+  use ExUnit.Case
+
+  alias BlueHeron.GATT.{Characteristic, Server, Service}
+
+  alias BlueHeron.ATT.{
+    ErrorResponse,
+    PrepareWriteRequest,
+    PrepareWriteResponse,
+    ExecuteWriteRequest,
+    ExecuteWriteResponse,
+    ReadBlobRequest,
+    ReadBlobResponse,
+    ReadByGroupTypeRequest,
+    ReadByGroupTypeResponse,
+    ReadByTypeRequest,
+    ReadByTypeResponse,
+    ReadRequest,
+    ReadResponse,
+    WriteRequest,
+    WriteResponse
+  }
+
+  defmodule TestServer do
+    @behaviour Server
+
+    @impl Server
+    def profile() do
+      [
+        Service.new(%{
+          id: :gap,
+          type: 0x1800,
+          characteristics: [
+            Characteristic.new(%{
+              id: {:gap, :device_name},
+              type: 0x2A00,
+              properties: 0b0000010
+            }),
+            Characteristic.new(%{
+              id: {:gap, :appearance},
+              type: 0x2A01,
+              properties: 0b0000010
+            })
+          ]
+        }),
+        Service.new(%{
+          id: :gatt,
+          type: 0x1801,
+          characteristics: [
+            Characteristic.new(%{
+              id: {:gatt, :service_changed},
+              type: 0x2A05,
+              properties: 0b00100000
+            })
+          ]
+        }),
+        Service.new(%{
+          id: :custom_service_1,
+          type: 0xBB5D5975D8E4853998F51335CDFFE9A,
+          characteristics: [
+            Characteristic.new(%{
+              id: {:custom_service_1, :short_uuid},
+              type: 0x1234,
+              properties: 0b0001010
+            }),
+            Characteristic.new(%{
+              id: {:custom_service_1, :long_uuid},
+              type: 0xF018E00E0ECE45B09617B744833D89BA,
+              properties: 0b0001010
+            })
+          ]
+        }),
+        Service.new(%{
+          id: :custom_service_2,
+          type: 0xBB5D5975D8E4853998F51335CDFFE9B,
+          characteristics: [
+            Characteristic.new(%{
+              id: {:custom_service_2, :short_uuid},
+              type: 0x1234,
+              properties: 0b0001010
+            }),
+            Characteristic.new(%{
+              id: {:custom_service_2, :long_uuid},
+              type: 0xF018E00E0ECE45B09617B744833D89BB,
+              properties: 0b0001010
+            })
+          ]
+        })
+      ]
+    end
+
+    @impl Server
+    def read({:gap, :device_name}) do
+      {:ok, "test-device"}
+    end
+
+    def read({:custom_service_1, :short_uuid}) do
+      {:ok, "a-value-longer-than-22-bytes"}
+    end
+
+    @impl Server
+    def write({:custom_service_1, :short_uuid}, value) do
+      send(self(), value)
+      :ok
+    end
+  end
+
+  test "discover all primary services" do
+    state = Server.init(TestServer)
+
+    # First, request primary services in the entire handle range
+    {state, response} =
+      Server.handle(state, %ReadByGroupTypeRequest{
+        uuid: 0x2800,
+        starting_handle: 0x0001,
+        ending_handle: 0xFFFF
+      })
+
+    # The Server must only return the :gap and :gatt service, as :test_service is of a
+    # different UUID length.
+    # The end_group_handle must be 0x0005, as that is the handle of the last
+    # attribute in the :gap service (the characteristic value handle for
+    # :appearance)
+    assert %ReadByGroupTypeResponse{
+             attribute_data: [
+               %ReadByGroupTypeResponse.AttributeData{
+                 handle: 0x0001,
+                 end_group_handle: 0x0005,
+                 uuid: 0x1800
+               },
+               %ReadByGroupTypeResponse.AttributeData{
+                 handle: 0x0006,
+                 end_group_handle: 0x0008,
+                 uuid: 0x1801
+               }
+             ]
+           } = response
+
+    # Next, request primary services in the remaining handle range.
+    {state, response} =
+      Server.handle(state, %ReadByGroupTypeRequest{
+        uuid: 0x2800,
+        starting_handle: 0x0009,
+        ending_handle: 0xFFFF
+      })
+
+    # The Server must now respond with :custom_service_1, as the response size
+    # is not big enough to fit two 16-byte UUID attributes
+    assert %ReadByGroupTypeResponse{
+             attribute_data: [
+               %ReadByGroupTypeResponse.AttributeData{
+                 handle: 0x0009,
+                 end_group_handle: 0x000D,
+                 uuid: 0xBB5D5975D8E4853998F51335CDFFE9A
+               }
+             ]
+           } = response
+
+    # Again, request primary services in the remaining handle range.
+    {state, response} =
+      Server.handle(state, %ReadByGroupTypeRequest{
+        uuid: 0x2800,
+        starting_handle: 0x000E,
+        ending_handle: 0xFFFF
+      })
+
+    # The Server must now respond with :custom_service_2
+    assert %ReadByGroupTypeResponse{
+             attribute_data: [
+               %ReadByGroupTypeResponse.AttributeData{
+                 handle: 0x000E,
+                 end_group_handle: 0x0012,
+                 uuid: 0xBB5D5975D8E4853998F51335CDFFE9B
+               }
+             ]
+           } = response
+
+    # Again, request primary services in the remaining handle range.
+    {_state, response} =
+      Server.handle(state, %ReadByGroupTypeRequest{
+        uuid: 0x2800,
+        starting_handle: 0x0013,
+        ending_handle: 0xFFFF
+      })
+
+    # The Server must return an error to indicate there are services in the
+    # requested handle range.
+    assert %ErrorResponse{error: :attribute_not_found} = response
+  end
+
+  test "discover all characteristics" do
+    state = Server.init(TestServer)
+
+    # Request all characteristics in the range of the :gap service
+    {state, response} =
+      Server.handle(state, %ReadByTypeRequest{
+        uuid: 0x2803,
+        starting_handle: 0x0001,
+        ending_handle: 0x0005
+      })
+
+    assert %ReadByTypeResponse{
+             attribute_data: [
+               %ReadByTypeResponse.AttributeData{
+                 handle: 0x0002,
+                 uuid: 0x2A00,
+                 characteristic_properties: 0b00000010,
+                 characteristic_value_handle: 0x0003
+               },
+               %ReadByTypeResponse.AttributeData{
+                 handle: 0x0004,
+                 uuid: 0x2A01,
+                 characteristic_properties: 0b00000010,
+                 characteristic_value_handle: 0x0005
+               }
+             ]
+           } = response
+
+    # Request all characteristics in the range of the :gatt service
+    {state, response} =
+      Server.handle(state, %ReadByTypeRequest{
+        uuid: 0x2803,
+        starting_handle: 0x0006,
+        ending_handle: 0x0008
+      })
+
+    # Server must respond with the :service_changed attribute
+    assert %ReadByTypeResponse{
+             attribute_data: [
+               %ReadByTypeResponse.AttributeData{
+                 handle: 0x0007,
+                 uuid: 0x2A05,
+                 characteristic_properties: 0b00100000,
+                 characteristic_value_handle: 0x0008
+               }
+             ]
+           } = response
+
+    # Request all characteristics in the range of :custom_service_1
+    {state, response} =
+      Server.handle(state, %ReadByTypeRequest{
+        uuid: 0x2803,
+        starting_handle: 0x0009,
+        ending_handle: 0x000D
+      })
+
+    # Server must only respond with characteristic with short UUID
+    assert %ReadByTypeResponse{
+             attribute_data: [
+               %ReadByTypeResponse.AttributeData{
+                 handle: 0x000A,
+                 uuid: 0x1234,
+                 characteristic_properties: 0b00001010,
+                 characteristic_value_handle: 0x000B
+               }
+             ]
+           } = response
+
+    # Request all characteristics in the remaining range of :custom_service_1
+    {_state, response} =
+      Server.handle(state, %ReadByTypeRequest{
+        uuid: 0x2803,
+        starting_handle: 0x000C,
+        ending_handle: 0x0000D
+      })
+
+    # Server must only respond with characteristic with long UUID
+    assert %ReadByTypeResponse{
+             attribute_data: [
+               %ReadByTypeResponse.AttributeData{
+                 handle: 0x000C,
+                 uuid: 0xF018E00E0ECE45B09617B744833D89BA,
+                 characteristic_properties: 0b00001010,
+                 characteristic_value_handle: 0x000D
+               }
+             ]
+           } = response
+  end
+
+  test "read short characteristic value" do
+    state = Server.init(TestServer)
+
+    {_state, response} = Server.handle(state, %ReadRequest{handle: 0x0003})
+
+    assert %ReadResponse{value: "test-device"} = response
+  end
+
+  test "read long characteristic value" do
+    state = Server.init(TestServer)
+    # Overhead per response is 1 byte
+    chunk_size = state.mtu - 1
+    expected_value = "a-value-longer-than-22-bytes"
+
+    [{first_chunk, _index} | remaining_indexed_chunks] =
+      expected_value
+      |> Stream.unfold(fn s -> String.split_at(s, chunk_size) end)
+      |> Enum.take_while(fn s -> s != "" end)
+      |> Enum.with_index()
+
+    {state, response} = Server.handle(state, %ReadRequest{handle: 0x000B})
+    assert %ReadResponse{value: ^first_chunk} = response
+
+    Enum.reduce(remaining_indexed_chunks, state, fn {chunk, index}, state ->
+      {state, response} =
+        Server.handle(state, %ReadBlobRequest{handle: 0x000B, offset: index * chunk_size})
+
+      assert %ReadBlobResponse{value: ^chunk} = response
+      state
+    end)
+  end
+
+  test "write short characteristic value" do
+    state = Server.init(TestServer)
+
+    {_state, response} =
+      Server.handle(state, %WriteRequest{handle: 0x0000B, value: "short-value"})
+
+    assert %WriteResponse{} = response
+
+    assert_receive "short-value"
+  end
+
+  test "write long characteristic value" do
+    state = Server.init(TestServer)
+    # Overhead per request & response is 5 bytes
+    chunk_size = state.mtu - 5
+    expected_value = "a-value-longer-than-22-bytes"
+
+    state =
+      expected_value
+      |> Stream.unfold(fn s -> String.split_at(s, chunk_size) end)
+      |> Enum.take_while(fn s -> s != "" end)
+      |> Enum.with_index()
+      |> Enum.reduce(state, fn {chunk, index}, state ->
+        offset = index * chunk_size
+
+        {state, response} =
+          Server.handle(state, %PrepareWriteRequest{
+            handle: 0x0000B,
+            value: chunk,
+            offset: offset
+          })
+
+        assert %PrepareWriteResponse{handle: 0x0000B, value: ^chunk, offset: ^offset} = response
+        state
+      end)
+
+    {_state, response} = Server.handle(state, %ExecuteWriteRequest{flags: 0x01})
+    assert %ExecuteWriteResponse{} = response
+
+    assert_receive ^expected_value
+  end
+end

--- a/test/blue_heron/gatt/server_test.exs
+++ b/test/blue_heron/gatt/server_test.exs
@@ -277,6 +277,81 @@ defmodule BlueHeron.GATT.ServerTest do
            } = response
   end
 
+  test "discover characteristics by uuid" do
+    state = Server.init(TestServer)
+
+    # Request all characteristics of type 0x2A00 (device name) in the range of
+    # the :gap service
+    {state, response} =
+      Server.handle(state, %ReadByTypeRequest{
+        uuid: 0x2A00,
+        starting_handle: 0x0001,
+        ending_handle: 0x0005
+      })
+
+    assert %ReadByTypeResponse{
+             attribute_data: [
+               %ReadByTypeResponse.AttributeData{
+                 handle: 0x0002,
+                 uuid: 0x2A00,
+                 characteristic_properties: 0b00000010,
+                 characteristic_value_handle: 0x0003
+               }
+             ]
+           } = response
+
+    # Request all characteristics of type 0x2A01 (appearance) in the range of
+    # the :gap service
+    {state, response} =
+      Server.handle(state, %ReadByTypeRequest{
+        uuid: 0x2A01,
+        starting_handle: 0x0001,
+        ending_handle: 0x0005
+      })
+
+    assert %ReadByTypeResponse{
+             attribute_data: [
+               %ReadByTypeResponse.AttributeData{
+                 handle: 0x0004,
+                 uuid: 0x2A01,
+                 characteristic_properties: 0b00000010,
+                 characteristic_value_handle: 0x0005
+               }
+             ]
+           } = response
+
+    # Request all characteristics of type 0x2A00 (device name) in the range of
+    # the :test_service_1 service
+    {state, response} =
+      Server.handle(state, %ReadByTypeRequest{
+        uuid: 0x2A00,
+        starting_handle: 0x0009,
+        ending_handle: 0x000D
+      })
+
+    assert %ErrorResponse{error: :attribute_not_found} = response
+
+    # Request all characteristics of type 0xF018E00E0ECE45B09617B744833D89BA (long uuid) in the range of
+    # the :test_service_1 service
+    {state, response} =
+      Server.handle(state, %ReadByTypeRequest{
+        uuid: 0xF018E00E0ECE45B09617B744833D89BA,
+        starting_handle: 0x0009,
+        ending_handle: 0x000D
+      })
+
+    assert %ReadByTypeResponse{
+             attribute_data: [
+               %ReadByTypeResponse.AttributeData{
+                 handle: 0x000C,
+                 uuid: 0xF018E00E0ECE45B09617B744833D89BA,
+                 characteristic_properties: 0b00001010,
+                 characteristic_value_handle: 0x000D
+               }
+             ]
+           } = response
+  end
+
   test "read short characteristic value" do
     state = Server.init(TestServer)
 

--- a/test/blue_heron/regression/btstack_govee_btled_test.exs
+++ b/test/blue_heron/regression/btstack_govee_btled_test.exs
@@ -835,7 +835,8 @@ defmodule BlueHeronRegressionTest do
       expected = %BlueHeron.HCI.Event.DisconnectionComplete{
         code: 5,
         connection_handle: 16,
-        reason: 0x16,
+        reason: 22,
+        reason_name: nil,
         status: 0
       }
 
@@ -879,8 +880,8 @@ defmodule BlueHeronRegressionTest do
           cid: 4,
           data: %BlueHeron.ATT.ExchangeMTUResponse{opcode: 3, server_rx_mtu: 23}
         },
-        flags: %{bc: 0, pb: 0},
-        handle: 528
+        flags: %{bc: 2, pb: 0},
+        handle: 16
       }
 
       actual = BlueHeron.ACL.deserialize(binary)
@@ -939,8 +940,8 @@ defmodule BlueHeronRegressionTest do
             opcode: 17
           }
         },
-        flags: %{bc: 0, pb: 0},
-        handle: 528
+        flags: %{bc: 2, pb: 0},
+        handle: 16
       }
 
       actual = BlueHeron.ACL.deserialize(binary)
@@ -989,8 +990,8 @@ defmodule BlueHeronRegressionTest do
             opcode: 17
           }
         },
-        flags: %{bc: 0, pb: 0},
-        handle: 528
+        flags: %{bc: 2, pb: 0},
+        handle: 16
       }
 
       actual = BlueHeron.ACL.deserialize(binary)
@@ -1039,8 +1040,8 @@ defmodule BlueHeronRegressionTest do
             opcode: 17
           }
         },
-        flags: %{bc: 0, pb: 0},
-        handle: 528
+        flags: %{bc: 2, pb: 0},
+        handle: 16
       }
 
       actual = BlueHeron.ACL.deserialize(binary)
@@ -1083,8 +1084,8 @@ defmodule BlueHeronRegressionTest do
             request_opcode: 16
           }
         },
-        flags: %{bc: 0, pb: 0},
-        handle: 528
+        flags: %{bc: 2, pb: 0},
+        handle: 16
       }
 
       actual = BlueHeron.ACL.deserialize(binary)
@@ -1146,8 +1147,8 @@ defmodule BlueHeronRegressionTest do
             opcode: 9
           }
         },
-        flags: %{bc: 0, pb: 0},
-        handle: 528
+        flags: %{bc: 2, pb: 0},
+        handle: 16
       }
 
       actual = BlueHeron.ACL.deserialize(binary)
@@ -1209,8 +1210,8 @@ defmodule BlueHeronRegressionTest do
             opcode: 9
           }
         },
-        flags: %{bc: 0, pb: 0},
-        handle: 528
+        flags: %{bc: 2, pb: 0},
+        handle: 16
       }
 
       actual = BlueHeron.ACL.deserialize(binary)
@@ -1260,8 +1261,8 @@ defmodule BlueHeronRegressionTest do
             opcode: 9
           }
         },
-        flags: %{bc: 0, pb: 0},
-        handle: 528
+        flags: %{bc: 2, pb: 0},
+        handle: 16
       }
 
       actual = BlueHeron.ACL.deserialize(binary)
@@ -1304,8 +1305,8 @@ defmodule BlueHeronRegressionTest do
             request_opcode: 8
           }
         },
-        flags: %{bc: 0, pb: 0},
-        handle: 528
+        flags: %{bc: 2, pb: 0},
+        handle: 16
       }
 
       actual = BlueHeron.ACL.deserialize(binary)
@@ -1355,8 +1356,8 @@ defmodule BlueHeronRegressionTest do
             opcode: 9
           }
         },
-        flags: %{bc: 0, pb: 0},
-        handle: 528
+        flags: %{bc: 2, pb: 0},
+        handle: 16
       }
 
       actual = BlueHeron.ACL.deserialize(binary)
@@ -1406,8 +1407,8 @@ defmodule BlueHeronRegressionTest do
             opcode: 9
           }
         },
-        flags: %{bc: 0, pb: 0},
-        handle: 528
+        flags: %{bc: 2, pb: 0},
+        handle: 16
       }
 
       actual = BlueHeron.ACL.deserialize(binary)
@@ -1457,8 +1458,8 @@ defmodule BlueHeronRegressionTest do
             opcode: 9
           }
         },
-        flags: %{bc: 0, pb: 0},
-        handle: 528
+        flags: %{bc: 2, pb: 0},
+        handle: 16
       }
 
       actual = BlueHeron.ACL.deserialize(binary)
@@ -1501,8 +1502,8 @@ defmodule BlueHeronRegressionTest do
             request_opcode: 8
           }
         },
-        flags: %{bc: 0, pb: 0},
-        handle: 528
+        flags: %{bc: 2, pb: 0},
+        handle: 16
       }
 
       actual = BlueHeron.ACL.deserialize(binary)
@@ -1575,8 +1576,8 @@ defmodule BlueHeronRegressionTest do
             opcode: 9
           }
         },
-        flags: %{bc: 0, pb: 0},
-        handle: 528
+        flags: %{bc: 2, pb: 0},
+        handle: 16
       }
 
       actual = BlueHeron.ACL.deserialize(binary)
@@ -1619,8 +1620,8 @@ defmodule BlueHeronRegressionTest do
             request_opcode: 8
           }
         },
-        flags: %{bc: 0, pb: 0},
-        handle: 528
+        flags: %{bc: 2, pb: 0},
+        handle: 16
       }
 
       actual = BlueHeron.ACL.deserialize(binary)


### PR DESCRIPTION
This PR adds the base functionality for BLE Peripherals:

- A `BlueHeron.Peripheral` module (and `:gen_statem` process), which is the starting point for library users. It includes:
  - An API for configuring, starting and stopping advertising
  - Handling of received ATT packets (by forwarding them to `BlueHeron. GATT.Server` and then replying to the client device)
- A `BlueHeron. GATT.Server` module, which handles the generic GATT pieces, and specifies a behaviour for the non-generic pieces: 
  - Implements (partial) service discovery for the profile specified by the behaviour implementation.
  - Ensures responses fit inside the ATT MTU
  - Handles reading/writing of long values without involving the library user
- `BlueHeron. GATT.Characteristic` and `BlueHeron. GATT.Service` modules used by the library user to describe the profile of the device.

At this point, the code is functional for a limited set of use cases. A non-comprehensive list of missing features (which I don't find necessary at this point):
- Handling of scan requests (for advertising)
- Authentication (bonding) and encryption (both of which are part of Security Manager Protocol)
- ATT MTU exchange
- Included & secondary services
- Characteristic descriptors and permissions
- GATT client API implementation for the Peripheral

I would like to write some bare-bones docs next. I expect to have them up before the end of the weekend.
