### PR TITLE
Fix ACL handle, pb and bc serde

### DIFF
--- a/lib/blue_heron/acl.ex
+++ b/lib/blue_heron/acl.ex
@@ -4,9 +4,12 @@ defmodule BlueHeron.ACL do
   defstruct [:handle, :flags, :data]
 
   def deserialize(
-        <<handle::little-12, pb::2, bc::2, length::little-16, acl_data::binary-size(length)>>
+        <<lower_handle, pb::2, bc::2, upper_handle::4, length::little-16,
+          acl_data::binary-size(length)>>
       ) do
     data = BlueHeron.L2Cap.deserialize(acl_data)
+
+    <<handle::little-12>> = <<lower_handle, upper_handle::4>>
 
     %ACL{
       handle: handle,
@@ -21,7 +24,8 @@ defmodule BlueHeron.ACL do
 
   def serialize(%ACL{data: data, handle: handle, flags: %{pb: pb, bc: bc}}) do
     length = byte_size(data)
-    <<handle::little-12, pb::2, bc::2, length::little-16, data::binary-size(length)>>
+    <<lower_handle, upper_handle::4>> = <<handle::little-12>>
+    <<lower_handle, pb::2, bc::2, upper_handle::4, length::little-16, data::binary-size(length)>>
   end
 
   def serialize(binary) when is_binary(binary), do: binary

--- a/test/blue_heron/acl_test.exs
+++ b/test/blue_heron/acl_test.exs
@@ -1,0 +1,37 @@
+defmodule BlueHeron.ACLTest do
+  use ExUnit.Case
+
+  alias BlueHeron.{ACL, ATT, L2Cap}
+
+  test "encodes packet correctly" do
+    serialized =
+      %ACL{
+        data: %L2Cap{
+          cid: 4,
+          data: %ATT.ExchangeMTURequest{client_rx_mtu: 185, opcode: 2}
+        },
+        flags: %{bc: 2, pb: 0},
+        handle: 64
+      }
+      |> ACL.serialize()
+
+    assert <<64, 32, 7, 0, 3, 0, 4, 0, 2, 185, 0>> == serialized
+  end
+
+  test "serde is symmetric" do
+    handle = Enum.random(0x001..0xEFF)
+    pb = Enum.random(0b00..0b11)
+    bc = Enum.random(0b00..0b11)
+
+    expected = %ACL{
+      flags: %{bc: bc, pb: pb},
+      handle: handle,
+      data: %L2Cap{
+        cid: 4,
+        data: %ATT.ExchangeMTURequest{client_rx_mtu: 185, opcode: 2}
+      }
+    }
+
+    assert expected == expected |> ACL.serialize() |> ACL.deserialize()
+  end
+end

--- a/test/blue_heron/regression/btstack_govee_btled_test.exs
+++ b/test/blue_heron/regression/btstack_govee_btled_test.exs
@@ -835,7 +835,8 @@ defmodule BlueHeronRegressionTest do
       expected = %BlueHeron.HCI.Event.DisconnectionComplete{
         code: 5,
         connection_handle: 16,
-        reason: 0x16,
+        reason: 22,
+        reason_name: nil,
         status: 0
       }
 
@@ -879,8 +880,8 @@ defmodule BlueHeronRegressionTest do
           cid: 4,
           data: %BlueHeron.ATT.ExchangeMTUResponse{opcode: 3, server_rx_mtu: 23}
         },
-        flags: %{bc: 0, pb: 0},
-        handle: 528
+        flags: %{bc: 2, pb: 0},
+        handle: 16
       }
 
       actual = BlueHeron.ACL.deserialize(binary)
@@ -939,8 +940,8 @@ defmodule BlueHeronRegressionTest do
             opcode: 17
           }
         },
-        flags: %{bc: 0, pb: 0},
-        handle: 528
+        flags: %{bc: 2, pb: 0},
+        handle: 16
       }
 
       actual = BlueHeron.ACL.deserialize(binary)
@@ -989,8 +990,8 @@ defmodule BlueHeronRegressionTest do
             opcode: 17
           }
         },
-        flags: %{bc: 0, pb: 0},
-        handle: 528
+        flags: %{bc: 2, pb: 0},
+        handle: 16
       }
 
       actual = BlueHeron.ACL.deserialize(binary)
@@ -1039,8 +1040,8 @@ defmodule BlueHeronRegressionTest do
             opcode: 17
           }
         },
-        flags: %{bc: 0, pb: 0},
-        handle: 528
+        flags: %{bc: 2, pb: 0},
+        handle: 16
       }
 
       actual = BlueHeron.ACL.deserialize(binary)
@@ -1083,8 +1084,8 @@ defmodule BlueHeronRegressionTest do
             request_opcode: 16
           }
         },
-        flags: %{bc: 0, pb: 0},
-        handle: 528
+        flags: %{bc: 2, pb: 0},
+        handle: 16
       }
 
       actual = BlueHeron.ACL.deserialize(binary)
@@ -1146,8 +1147,8 @@ defmodule BlueHeronRegressionTest do
             opcode: 9
           }
         },
-        flags: %{bc: 0, pb: 0},
-        handle: 528
+        flags: %{bc: 2, pb: 0},
+        handle: 16
       }
 
       actual = BlueHeron.ACL.deserialize(binary)
@@ -1209,8 +1210,8 @@ defmodule BlueHeronRegressionTest do
             opcode: 9
           }
         },
-        flags: %{bc: 0, pb: 0},
-        handle: 528
+        flags: %{bc: 2, pb: 0},
+        handle: 16
       }
 
       actual = BlueHeron.ACL.deserialize(binary)
@@ -1260,8 +1261,8 @@ defmodule BlueHeronRegressionTest do
             opcode: 9
           }
         },
-        flags: %{bc: 0, pb: 0},
-        handle: 528
+        flags: %{bc: 2, pb: 0},
+        handle: 16
       }
 
       actual = BlueHeron.ACL.deserialize(binary)
@@ -1304,8 +1305,8 @@ defmodule BlueHeronRegressionTest do
             request_opcode: 8
           }
         },
-        flags: %{bc: 0, pb: 0},
-        handle: 528
+        flags: %{bc: 2, pb: 0},
+        handle: 16
       }
 
       actual = BlueHeron.ACL.deserialize(binary)
@@ -1355,8 +1356,8 @@ defmodule BlueHeronRegressionTest do
             opcode: 9
           }
         },
-        flags: %{bc: 0, pb: 0},
-        handle: 528
+        flags: %{bc: 2, pb: 0},
+        handle: 16
       }
 
       actual = BlueHeron.ACL.deserialize(binary)
@@ -1406,8 +1407,8 @@ defmodule BlueHeronRegressionTest do
             opcode: 9
           }
         },
-        flags: %{bc: 0, pb: 0},
-        handle: 528
+        flags: %{bc: 2, pb: 0},
+        handle: 16
       }
 
       actual = BlueHeron.ACL.deserialize(binary)
@@ -1457,8 +1458,8 @@ defmodule BlueHeronRegressionTest do
             opcode: 9
           }
         },
-        flags: %{bc: 0, pb: 0},
-        handle: 528
+        flags: %{bc: 2, pb: 0},
+        handle: 16
       }
 
       actual = BlueHeron.ACL.deserialize(binary)
@@ -1501,8 +1502,8 @@ defmodule BlueHeronRegressionTest do
             request_opcode: 8
           }
         },
-        flags: %{bc: 0, pb: 0},
-        handle: 528
+        flags: %{bc: 2, pb: 0},
+        handle: 16
       }
 
       actual = BlueHeron.ACL.deserialize(binary)
@@ -1575,8 +1576,8 @@ defmodule BlueHeronRegressionTest do
             opcode: 9
           }
         },
-        flags: %{bc: 0, pb: 0},
-        handle: 528
+        flags: %{bc: 2, pb: 0},
+        handle: 16
       }
 
       actual = BlueHeron.ACL.deserialize(binary)
@@ -1619,8 +1620,8 @@ defmodule BlueHeronRegressionTest do
             request_opcode: 8
           }
         },
-        flags: %{bc: 0, pb: 0},
-        handle: 528
+        flags: %{bc: 2, pb: 0},
+        handle: 16
       }
 
       actual = BlueHeron.ACL.deserialize(binary)


### PR DESCRIPTION
This fixes serialisation and deserialisation of ACL fields `handle`, `pb`, and `bc`. 

The packet format is described in "5.4.2 HCI ACL Data Packets" in the spec. The graphic is misleading however, as it seems that the 12 bits of handle are contiguous. By looking at packet logs in Wireshark, I've found that it's **not** contiguous.