### PR TITLE
Fix unknown acl message ATT client

### DIFF
--- a/lib/blue_heron/att/client.ex
+++ b/lib/blue_heron/att/client.ex
@@ -364,7 +364,7 @@ defmodule BlueHeron.ATT.Client do
   end
 
   def connected(:info, {:HCI_ACL_DATA_PACKET, acl}, _data) do
-    Logger.info("Unhandled ACL packet: #{inspect(acl)}")
+    Logger.info("ATT.Client: Unhandled ACL packet: #{inspect(acl)}")
     :keep_state_and_data
   end
 

--- a/lib/blue_heron/att/client.ex
+++ b/lib/blue_heron/att/client.ex
@@ -363,6 +363,11 @@ defmodule BlueHeron.ATT.Client do
     :keep_state_and_data
   end
 
+  def connected(:info, {:HCI_ACL_DATA_PACKET, acl}, _data) do
+    Logger.info("Unhandled ACL packet: #{inspect(acl)}")
+    :keep_state_and_data
+  end
+
   # def connected(:info, {:HCI_ACL_DATA_PACKET, %ACL{data: %L2Cap{cid: 4, data: %ReadByGroupTypeResponse{} = response}}}, data) do
   #   {pid, _} = data.caller
   #   send pid, self(), {__MODULE__, response}


### PR DESCRIPTION
running latest main (but error has always been there afaik) - I'm getting this error/crash just upon succesful connection to a (low quality) led strip (very similar code to the govee example - nothing fancy)

```
Evaluation process terminated - an exception was raised:
    ** (FunctionClauseError) no function clause matching in BlueHeron.ATT.Client.connected/3
        (blue_heron 0.2.1) lib/blue_heron/att/client.ex:240: BlueHeron.ATT.Client.connected(:info, {:HCI_ACL_DATA_PACKET, %BlueHeron.ACL{data: %BlueHeron.L2Cap{cid: 5, data: <<18, 1, 8, 0, 16, 0, 20, 0, 12, 0, 200, 0>>}, flags: %{bc: 2, pb: 0}, handle: 64}}, %BlueHeron.ATT.Client{attributes: [], caller: nil, client_mtu: 1961, connection: %BlueHeron.HCI.Event.LEMeta.ConnectionComplete{code: 62, connection_handle: 64, connection_interval: 24, connection_latency: 4, master_clock_accuracy: 0, peer_address: 209496961988077, peer_address_type: 0, role: 0, status: 0, subevent_code: 1, supervision_timeout: 72}, connection_timer: nil, controlling_process: #PID<0.2855.0>, create_connection: %BlueHeron.HCI.Command.LEController.CreateConnection{connection_interval_max: 24, connection_interval_min: 8, connection_latency: 4, initiator_filter_policy: 0, le_scan_interval: 96, le_scan_window: 48, max_ce_length: 48, min_ce_length: 2, ocf: 13, ogf: 8, opcode: "\r ", own_address_type: 0, peer_address: 209496961988077, peer_address_type: 0, supervision_timeout: 72}, ctx: #BlueHeron.Context<0.2856.0>, server_mtu: 23, starting_handle: 1})
```

looks to be a BlueHeron.ATT.WriteRequest - and should probably be handled/forwarded, but for now this PR just avoids crashing and logs the unhandled message..

with this PR, no crash and log reads:

`18:57:03.427 [info]  ATT.Client: Unhandled ACL packet: %BlueHeron.ACL{data: %BlueHeron.L2Cap{cid: 5, data: <<18, 1, 8, 0, 16, 0, 20, 0, 12, 0, 200, 0>>}, flags: %{bc: 2, pb: 0}, handle: 64}`
