### PR TITLE
Add API documentation for GATT modules

### DIFF
--- a/lib/blue_heron/gatt/characteristic.ex
+++ b/lib/blue_heron/gatt/characteristic.ex
@@ -1,10 +1,30 @@
 defmodule BlueHeron.GATT.Characteristic do
+  @moduledoc """
+  Struct that represents a GATT characteristic.
+  """
+  @opaque t() :: map()
+
   defstruct [:id, :type, :properties, :handle, :value_handle]
 
-  # id is required, can be any term, but must be unique within the services() function
-  # type is required, must be either 16 or 128 bit UUID
-  # properties is required, must be an integer between 0 and 255
-  # handle and value_handle should not be specified by the user
+  @doc """
+  Create a characteristic with fields taken from the map `args`.
+
+  The following fields are required:
+  - `id`: A user-defined term to identify the characteristic. Must be unique within the device profile.
+     Can be any Erlang term.
+  - `type`: The characteristic type UUID. Can be a 2- or 16-byte byte UUID. Integer.
+  - `properties`: The characteristic property flags. Integer.
+
+  ## Example:
+
+      iex> BlueHeron.GATT.Characteristic.new(%{
+      ...>   id: :fancy_key,
+      ...>   type: 0x2e0f8e717a7d4690998377626bc6b657,
+      ...>   properties: 0b00000010
+      ...> })
+      %BlueHeron.GATT.Characteristic{id: :fancy_key, type: 0x2e0f8e717a7d4690998377626bc6b657, properties: 2}
+  """
+  @spec new(args :: map()) :: t()
   def new(args) do
     args = Map.take(args, [:id, :type, :properties])
     struct!(__MODULE__, args)

--- a/lib/blue_heron/gatt/server.ex
+++ b/lib/blue_heron/gatt/server.ex
@@ -1,4 +1,67 @@
 defmodule BlueHeron.GATT.Server do
+  @moduledoc """
+  A behaviour module for implementing a GATT server.
+
+  This module handles all generic aspects of the GATT protocol, including MTU
+  exchange and service discovery. The callback module is invoked for a
+  description of the GATT profile (services and characteristics), as well as
+  reading and writing characteristic values.
+
+  Example callback module:
+
+      defmodule MyApp.MyGattServer do
+        @behaviour BlueHeron.GATT.Server
+
+        @impl BlueHeron.GATT.Server
+        def profile() do
+          [
+            BlueHeron.GATT.Service.new(%{
+              id: :gap,
+              type: 0x1800,
+              characteristics: [
+                BlueHeron.GATT.Characteristic.new(%{
+                  id: {:gap, :device_name},
+                  type: 0x2A00,
+                  properties: 0b0000010
+                }),
+                BlueHeron.GATT.Characteristic.new(%{
+                  id: {:gap, :appearance},
+                  type: 0x2A01,
+                  properties: 0b0000010
+                })
+              ]
+            }),
+            BlueHeron.GATT.Service.new(%{
+              id: :my_custom_service,
+              type: 0xBB5D5975D8E4853998F51335CDFFE9A,
+              characteristics: [
+                BlueHeron.GATT.Characteristic.new(%{
+                  id: {:my_custom_service, :my_custom_characteristic},
+                  type: 0x1234,
+                  properties: 0b0001010
+                }),
+                BlueHeron.GATT.Characteristic.new(%{
+                  id: {:my_custom_service, :another_custom_characteristic},
+                  type: 0xF018E00E0ECE45B09617B744833D89BA,
+                  properties: 0b0001010
+                })
+              ]
+            })
+          ]
+        end
+
+        @impl BlueHeron.GATT.Server
+        def read({:gap, :device_name}) do
+          "my-device-name"
+        end
+
+        @impl BlueHeron.GATT.Server
+        def write({:my_custom_serivce, :my_custom_characteristic}, value) do
+          MyApp.DB.insert(:my_custom_characteristic, value)
+        end
+      end
+  """
+
   alias BlueHeron.ATT.{
     ErrorResponse,
     ExchangeMTURequest,
@@ -22,16 +85,36 @@ defmodule BlueHeron.GATT.Server do
 
   alias BlueHeron.GATT.Service
 
-  @callback profile() :: [Service.t()]
-  @callback read(any()) :: {:ok, binary()} | {:error, term()}
-  @callback write(any(), binary()) :: :ok | {:error, term()}
+  @doc """
+  Return the list of services that make up the GATT profile of the device.
 
-  defstruct [:mod, :profile, :mtu, :write_handle, :write_buffer]
+  This callback is only invoked when the GATT server is started, as the profile
+  is assumed to be static.
+
+  To comply with the Bluetooth specification, the profile must include a "GAP"
+  service (type UUID 0x1800), which must have characteristics for "Device Name"
+  (type UUID 0x2A00) and "Appearance" (type UUID 0x2A01).
+  """
+  @callback profile() :: [Service.t()]
+
+  @doc """
+  Return the value of the characteristic given by `id`.
+  The value must be serialized as a binary.
+  """
+  @callback read(id :: any()) :: binary()
+
+  @doc """
+  Handle a write to the characteristic given by `id`.
+  """
+  @callback write(id :: any(), value :: binary()) :: :ok
+
+  defstruct [:mod, :profile, :mtu, :read_buffer, :write_requests]
 
   @discover_all_primary_services 0x2800
   @find_included_services 0x2802
   @discover_all_characteristics 0x2803
 
+  @doc false
   def init(mod) do
     profile = hydrate(mod.profile())
 
@@ -39,11 +122,12 @@ defmodule BlueHeron.GATT.Server do
       mod: mod,
       profile: profile,
       mtu: 23,
-      write_handle: nil,
-      write_buffer: ""
+      read_buffer: <<>>,
+      write_requests: []
     }
   end
 
+  @doc false
   def handle(state, request) do
     case request do
       %ExchangeMTURequest{} ->
@@ -81,15 +165,14 @@ defmodule BlueHeron.GATT.Server do
     end
   end
 
-  def exchange_mtu(state, _request) do
+  defp exchange_mtu(state, _request) do
     {state, %ExchangeMTUResponse{server_rx_mtu: state.mtu}}
   end
 
-  def discover_all_primary_services(state, request) do
+  defp discover_all_primary_services(state, request) do
     services =
       Enum.filter(state.profile, fn service ->
-        service.primary? and service.handle >= request.starting_handle and
-          service.handle <= request.ending_handle
+        service.handle >= request.starting_handle and service.handle <= request.ending_handle
       end)
 
     case services do
@@ -118,40 +201,17 @@ defmodule BlueHeron.GATT.Server do
     end
   end
 
-  def find_included_services(state, request) do
-    services =
-      Enum.filter(state.profile, fn service ->
-        not service.primary? and service.handle >= request.starting_handle and
-          service.handle <= request.ending_handle
-      end)
-
-    case services do
-      [] ->
-        {state,
-         %ErrorResponse{
-           handle: request.starting_handle,
-           request_opcode: request.opcode,
-           error: :attribute_not_found
-         }}
-
-      services_in_range ->
-        attribute_data =
-          services_in_range
-          |> Enum.map(fn service ->
-            %ReadByGroupTypeResponse.AttributeData{
-              handle: service.handle,
-              end_group_handle: service.end_group_handle,
-              uuid: service.type
-            }
-          end)
-          |> filter_by_uuid_size()
-          |> limit_attribute_count(state.mtu)
-
-        {state, %ReadByGroupTypeResponse{attribute_data: attribute_data}}
-    end
+  defp find_included_services(state, request) do
+    # TODO: Implement
+    {state,
+     %ErrorResponse{
+       handle: request.starting_handle,
+       request_opcode: request.opcode,
+       error: :attribute_not_found
+     }}
   end
 
-  def discover_all_characteristics(state, request) do
+  defp discover_all_characteristics(state, request) do
     characteristics =
       state.profile
       |> Enum.flat_map(fn service -> service.characteristics end)
@@ -187,7 +247,7 @@ defmodule BlueHeron.GATT.Server do
     end
   end
 
-  def discover_characteristics_by_uuid(state, request) do
+  defp discover_characteristics_by_uuid(state, request) do
     characteristics =
       state.profile
       |> Enum.filter(fn service ->
@@ -227,7 +287,7 @@ defmodule BlueHeron.GATT.Server do
     end
   end
 
-  def discover_all_characteristic_descriptors(state, request) do
+  defp discover_all_characteristic_descriptors(state, request) do
     # TODO: Implement
     {state,
      %ErrorResponse{
@@ -237,52 +297,57 @@ defmodule BlueHeron.GATT.Server do
      }}
   end
 
-  def read_characteristic_value(state, request) do
+  defp read_characteristic_value(state, request) do
     id = find_characteristic_id(state.profile, request.handle)
-    {:ok, value} = state.mod.read(id)
+    value = state.mod.read(id)
 
-    # TODO: Might want to cache the value if it's longer than MTU - 1, and then
-    # serve the read_long_characteristic_value requests from that cache
-    # in order to avoid inconsistent reads if the value is updated during the read operation.
-    value =
-      if byte_size(value) > state.mtu - 1 do
-        :binary.part(value, 0, state.mtu - 1)
-      else
-        value
-      end
+    # We cache the value if it's longer than MTU - 1, to avoid inconsistent
+    # reads if the value is updated during the read operation. We assume that
+    # the client will only attempt to read one characteristic at a time.
+    case read_bytes(value, state.mtu - 1) do
+      {:partial, partial_value, value} ->
+        state = %{state | read_buffer: value}
+        {state, %ReadResponse{value: partial_value}}
 
-    {state, %ReadResponse{value: value}}
+      {:complete, value} ->
+        state = %{state | read_buffer: nil}
+        {state, %ReadResponse{value: value}}
+    end
   end
 
-  def read_long_characteristic_value(state, request) do
+  defp read_long_characteristic_value(state, request) do
     id = find_characteristic_id(state.profile, request.handle)
-    {:ok, value} = state.mod.read(id)
 
-    value =
-      if byte_size(value) - request.offset > state.mtu - 1 do
-        :binary.part(value, request.offset, state.mtu - 1)
-      else
-        :binary.part(value, request.offset, byte_size(value) - request.offset)
+    read_result =
+      case state.read_buffer do
+        nil ->
+          value = state.mod.read(id)
+          read_bytes(value, state.mtu - 1, request.offset)
+
+        value ->
+          read_bytes(value, state.mtu - 1, request.offset)
       end
 
-    {state, %ReadBlobResponse{value: value}}
+    case read_result do
+      {:partial, partial_value, value} ->
+        state = %{state | read_buffer: value}
+        {state, %ReadBlobResponse{value: partial_value}}
+
+      {:complete, value} ->
+        state = %{state | read_buffer: nil}
+        {state, %ReadBlobResponse{value: value}}
+    end
   end
 
-  def write_characteristic_value(state, request) do
+  defp write_characteristic_value(state, request) do
     id = find_characteristic_id(state.profile, request.handle)
     :ok = state.mod.write(id, request.value)
 
     {state, %WriteResponse{}}
   end
 
-  def write_long_characteristic_value(state, %PrepareWriteRequest{} = request) do
-    # TODO: Probably want to store a list of write-operations and only materialize the resulting binary
-    # when receiving the ExecuteWriteRequest - in case the PrepareWriteRequest do not arrive in order.
-    state = %{
-      state
-      | write_handle: request.handle,
-        write_buffer: state.write_buffer <> request.value
-    }
+  defp write_long_characteristic_value(state, %PrepareWriteRequest{} = request) do
+    state = %{state | write_requests: [request | state.write_requests]}
 
     {state,
      %PrepareWriteResponse{
@@ -292,26 +357,30 @@ defmodule BlueHeron.GATT.Server do
      }}
   end
 
-  def write_long_characteristic_value(state, %ExecuteWriteRequest{flags: 1}) do
-    id = find_characteristic_id(state.profile, state.write_handle)
-    :ok = state.mod.write(id, state.write_buffer)
-    state = %{state | write_handle: nil, write_buffer: ""}
+  defp write_long_characteristic_value(state, %ExecuteWriteRequest{flags: 1}) do
+    [req | _] = state.write_requests
+    id = find_characteristic_id(state.profile, req.handle)
+
+    value =
+      state.write_requests
+      |> Enum.sort(fn first, second -> first.offset < second.offset end)
+      |> Enum.map(fn req -> req.value end)
+      |> Enum.into(<<>>)
+
+    :ok = state.mod.write(id, value)
+    state = %{state | write_requests: []}
 
     {state, %ExecuteWriteResponse{}}
   end
 
-  def write_long_characteristic_value(state, %ExecuteWriteRequest{flags: 0}) do
-    state = %{state | write_handle: nil, write_buffer: ""}
+  defp write_long_characteristic_value(state, %ExecuteWriteRequest{flags: 0}) do
+    state = %{state | write_requests: []}
 
     {state, %ExecuteWriteResponse{}}
   end
 
   defp hydrate(profile) do
-    # To each service, assign a handle and end handle
-    # assign handle to characteristics as well
-    # Maybe also create a characteristic.value_handle => characteristic.id
     # TODO: Check that ID's are unique
-    # TODO: Check the services with primary?: false are included in other services
     {_next_handle, profile} =
       Enum.reduce(profile, {1, []}, fn service, {next_handle, acc} ->
         service_handle = next_handle
@@ -350,7 +419,8 @@ defmodule BlueHeron.GATT.Server do
   end
 
   # The serialized size of the response is not allowed to exceed the MTU
-  # The serialized size can be calculated as size = overhead + length(attributes) * bytes_per_attribute
+  # The serialized size can be calculated as:
+  # size = overhead + length(attributes) * bytes_per_attribute
   defp limit_attribute_count(attributes, mtu) do
     {bytes_per_attribute, overhead} =
       case hd(attributes) do
@@ -379,5 +449,13 @@ defmodule BlueHeron.GATT.Server do
     |> Enum.find_value(fn characteristic ->
       if characteristic.value_handle == characteristic_value_handle, do: characteristic.id
     end)
+  end
+
+  defp read_bytes(value, length, offset \\ 0) do
+    if byte_size(value) - offset > length do
+      {:partial, :binary.part(value, offset, length), value}
+    else
+      {:complete, :binary.part(value, offset, byte_size(value) - offset)}
+    end
   end
 end

--- a/lib/blue_heron/gatt/service.ex
+++ b/lib/blue_heron/gatt/service.ex
@@ -1,25 +1,44 @@
 defmodule BlueHeron.GATT.Service do
-  @type t() :: map()
+  @moduledoc """
+  Struct that represents a GATT service.
+  """
+  @opaque t() :: map()
 
   defstruct [
     :id,
-    :primary?,
     :type,
-    :included_services,
     :characteristics,
     :handle,
     :end_group_handle
   ]
 
-  # id is required, can be any term, but must be unique within the services() function
-  # primary? defaults to true, set it to false if it should only show up as an included service
-  # type is required, must be either 16 or 128 bit UUID
-  # included_services is a list of service ID's to be included in the definition of this service
-  # characteristics is a list of characteristics
+  @doc """
+  Create a service with fields taken from the map `args`.
+
+  The following fields are required:
+  - `id`: A user-defined term to identify the service. Must be unique within the device profile.
+     Can be any Erlang term.
+  - `type`: The service type UUID. Can be a 2- or 16-byte byte UUID. Integer.
+  - `characteristics`: A list of characteristics.
+
+  ## Example:
+
+      iex> BlueHeron.GATT.Service.new(%{
+      ...>   id: :gap,
+      ...>   type: 0x1800,
+      ...>   characteristics: [
+      ...>     BlueHeron.GATT.Characteristic.new(%{
+      ...>       id: {:gap, :device_name},
+      ...>       type: 0x2A00,
+      ...>       properties: 0b00000010
+      ...>     })
+      ...>   ]
+      ...> })
+      %BlueHeron.GATT.Service{id: :gap, type: 0x1800, characteristics: [%BlueHeron.GATT.Characteristic{id: {:gap, :device_name}, type: 0x2A00, properties: 2}]}
+  """
+  @spec new(args :: map()) :: t()
   def new(args) do
-    args =
-      Map.put_new(args, :primary?, true)
-      |> Map.take([:id, :primary?, :type, :included_services, :characteristics])
+    args = Map.take(args, [:id, :type, :characteristics])
 
     struct!(__MODULE__, args)
   end

--- a/test/blue_heron/gatt/characteristic_test.exs
+++ b/test/blue_heron/gatt/characteristic_test.exs
@@ -1,0 +1,5 @@
+defmodule BlueHeron.GATT.CharacteristicTest do
+  use ExUnit.Case
+
+  doctest BlueHeron.GATT.Characteristic
+end

--- a/test/blue_heron/gatt/server_test.exs
+++ b/test/blue_heron/gatt/server_test.exs
@@ -91,11 +91,11 @@ defmodule BlueHeron.GATT.ServerTest do
 
     @impl Server
     def read({:gap, :device_name}) do
-      {:ok, "test-device"}
+      "test-device"
     end
 
     def read({:custom_service_1, :short_uuid}) do
-      {:ok, "a-value-longer-than-22-bytes"}
+      "a-value-longer-than-22-bytes"
     end
 
     @impl Server
@@ -333,7 +333,7 @@ defmodule BlueHeron.GATT.ServerTest do
 
     # Request all characteristics of type 0xF018E00E0ECE45B09617B744833D89BA (long uuid) in the range of
     # the :test_service_1 service
-    {state, response} =
+    {_state, response} =
       Server.handle(state, %ReadByTypeRequest{
         uuid: 0xF018E00E0ECE45B09617B744833D89BA,
         starting_handle: 0x0009,

--- a/test/blue_heron/gatt/service_test.exs
+++ b/test/blue_heron/gatt/service_test.exs
@@ -1,0 +1,5 @@
+defmodule BlueHeron.GATT.ServiceTest do
+  use ExUnit.Case
+
+  doctest BlueHeron.GATT.Service
+end


### PR DESCRIPTION
Note that this isn't just documentation - it also contains some changes to the code, including breaking changes to the current API:

 - I removed the parts related to primary/secondary/included services. I found the implementation was wrong, and fixing it was more work than I wanted. So now the API has been constrained to only primary services.
 - I changed the return-type signature of read and write server callbacks. I previously left the door open to returning error tuples, as this was how I planned to check authorization failures, but I've abandoned that idea. Maybe it will return in the future, when we cross that bridge 😄 
 - I implemented a read buffer to ensure long reads are consistent.
 - I changed the write buffer implementation to handle out-of-order write requests.