### PR TITLE
Add SetRandomAddress HCI command

### DIFF
--- a/lib/blue_heron/hci/command.ex
+++ b/lib/blue_heron/hci/command.ex
@@ -28,6 +28,7 @@ defmodule BlueHeron.HCI.Command do
     LEController.SetAdvertisingData,
     LEController.SetAdvertisingEnable,
     LEController.SetAdvertisingParameters,
+    LEController.SetRandomAddress,
     LEController.SetScanEnable,
     LEController.SetScanParameters,
     LinkPolicy.WriteDefaultLinkPolicySettings

--- a/lib/blue_heron/hci/commands/le_controller/set_random_address.ex
+++ b/lib/blue_heron/hci/commands/le_controller/set_random_address.ex
@@ -1,0 +1,26 @@
+defmodule BlueHeron.HCI.Command.LEController.SetRandomAddress do
+  use BlueHeron.HCI.Command.LEController, ocf: 0x0005
+
+  defparameters random_address: nil
+
+  defimpl BlueHeron.HCI.Serializable do
+    def serialize(command) do
+      <<command.opcode::binary, 0x06, command.random_address::little-48>>
+    end
+  end
+
+  @impl BlueHeron.HCI.Command
+  def deserialize(<<@opcode::binary, _fields_size, random_address::little-48>>) do
+    new(random_address: random_address)
+  end
+
+  @impl BlueHeron.HCI.Command
+  def deserialize_return_parameters(<<status>>) do
+    %{status: status}
+  end
+
+  @impl BlueHeron.HCI.Command
+  def serialize_return_parameters(%{status: status}) do
+    <<BlueHeron.ErrorCode.to_code!(status)>>
+  end
+end

--- a/test/blue_heron/hci/command/le_controller/set_random_address_test.exs
+++ b/test/blue_heron/hci/command/le_controller/set_random_address_test.exs
@@ -1,0 +1,28 @@
+defmodule BlueHeron.HCI.Command.LEController.SetRandomAddressTest do
+  use ExUnit.Case
+
+  alias BlueHeron.HCI.Command.LEController.SetRandomAddress
+
+  test "encodes parameters correctly" do
+    serialized =
+      %SetRandomAddress{
+        random_address: 0x112233445566
+      }
+      |> BlueHeron.HCI.Serializable.serialize()
+
+    assert <<0x05, 0x20, 0x06, 0x66, 0x55, 0x44, 0x33, 0x22, 0x11>> == serialized
+  end
+
+  test "serde is symmetric" do
+    random_address = Enum.random(0x000000000000..0xFFFFFFFFFFFF)
+
+    expected = %SetRandomAddress{
+      random_address: random_address
+    }
+
+    assert expected ==
+             expected
+             |> BlueHeron.HCI.Serializable.serialize()
+             |> SetRandomAddress.deserialize()
+  end
+end


### PR DESCRIPTION
Some Bluetooth modules (like those used in RPi3 and RPi4) do not ship with a Public Device Address devices (MAC address registered with IEEE). Thus, if you just start advertising with the standard config, it will advertise with a "null" address (AA:AA:AA:AA:AA:AA), as seen here:

![image](https://user-images.githubusercontent.com/6442970/140059214-2a285903-76c7-41fe-9f68-ef7bb824c765.png)

To avoid this, we need to:
1) Set a Random Device Address (using the command included in this PR)
2) Configure advertising to use the random device address (can be done with the Peripheral API like this: `BlueHeron.Peripheral.set_advertising_parameters(peripheral, %{own_address_type: 0x01})`)

For more info, see the Bluetooth spec at Version 4.2 [Vol 6, Part B], section 1.3 DEVICE ADDRESS.