### PR TITLE
Add connection status notifications to peripheral controlling process

### DIFF
--- a/lib/peripheral.ex
+++ b/lib/peripheral.ex
@@ -105,6 +105,7 @@ defmodule BlueHeron.Peripheral do
   end
 
   def advertising(:info, {:HCI_EVENT_PACKET, %ConnectionComplete{} = event}, data) do
+    send(data.controlling_process, {__MODULE__, :connected})
     gatt_server = GATT.Server.init(data.gatt_handler)
 
     {:next_state, :connected,
@@ -143,6 +144,7 @@ defmodule BlueHeron.Peripheral do
   end
 
   def connected(:info, {:HCI_EVENT_PACKET, %DisconnectionComplete{}}, data) do
+    send(data.controlling_process, {__MODULE__, :disconnected})
     {:next_state, :ready, %{data | gatt_server: nil, conn_handle: nil}}
   end
 end


### PR DESCRIPTION
This PR now contains two related additions to the Peripheral module:

- connection status notifications for the Peripheral's controlling process
- an API for disconnecting a connected Peripheral 

 My use case looks like this:

I have my own Bluetooth Manager process in the supervision tree. That process spawns a Peripheral, and enables advertising. When another device connects to my device, I need to start a session. This is handled by the Bluetooth Manager process, which receives the `{BlueHeron.Peripheral, :connected}` message to start the session and `{BlueHeron.Peripheral, :disconnected}` to end the session. If the session times out, it will call `Peripheral.disconnect/1` to close the connection.

