### PR TITLE
Fix connection_handle serde in HCI events

### DIFF
--- a/lib/blue_heron/hci/events/disconnection_complete.ex
+++ b/lib/blue_heron/hci/events/disconnection_complete.ex
@@ -28,9 +28,12 @@ defmodule BlueHeron.HCI.Event.DisconnectionComplete do
 
   defimpl BlueHeron.HCI.Serializable do
     def serialize(dc) do
+      <<lower_handle, upper_handle::4>> = <<dc.connection_handle::little-12>>
+      connection_handle = <<lower_handle, 0::4, upper_handle::4>>
+
       bin = <<
         dc.status,
-        dc.connection_handle::little-16,
+        connection_handle::binary,
         dc.reason
       >>
 
@@ -41,7 +44,9 @@ defmodule BlueHeron.HCI.Event.DisconnectionComplete do
   end
 
   @impl BlueHeron.HCI.Event
-  def deserialize(<<@code, _size, status, connection_handle::little-16, reason>>) do
+  def deserialize(<<@code, _size, status, lower_handle, _::4, upper_handle::4, reason>>) do
+    <<connection_handle::little-12>> = <<lower_handle, upper_handle::4>>
+
     %__MODULE__{
       connection_handle: connection_handle,
       reason: reason,

--- a/lib/blue_heron/hci/events/le_meta/connection_complete.ex
+++ b/lib/blue_heron/hci/events/le_meta/connection_complete.ex
@@ -38,10 +38,13 @@ defmodule BlueHeron.HCI.Event.LEMeta.ConnectionComplete do
 
   defimpl BlueHeron.HCI.Serializable do
     def serialize(cc) do
+      <<lower_handle, upper_handle::4>> = <<cc.connection_handle::little-12>>
+      connection_handle = <<lower_handle, 0::4, upper_handle::4>>
+
       bin = <<
         cc.subevent_code,
         cc.status,
-        cc.connection_handle::little-16,
+        connection_handle::binary,
         cc.role,
         cc.peer_address_type,
         cc.peer_address::little-48,
@@ -61,8 +64,9 @@ defmodule BlueHeron.HCI.Event.LEMeta.ConnectionComplete do
   def deserialize(<<@code, _size, @subevent_code, bin::binary>>) do
     <<
       status,
-      connection_handle::little-12,
+      lower_handle,
       _::4,
+      upper_handle::4,
       role,
       peer_address_type,
       peer_address::little-48,
@@ -71,6 +75,8 @@ defmodule BlueHeron.HCI.Event.LEMeta.ConnectionComplete do
       supervision_timeout::little-16,
       master_clock_accuracy
     >> = bin
+
+    <<connection_handle::little-12>> = <<lower_handle, upper_handle::4>>
 
     %__MODULE__{
       subevent_code: @subevent_code,


### PR DESCRIPTION
@ConnorRigby found that the [connection handle check in Peripheral](https://github.com/blue-heron/blue_heron/blob/main/lib/peripheral.ex#L132) would consistently fail in his environment.

By looking at the HCI dumps in Wireshark I found that this is because the connection_handle was being deserialized incorrectly in the LEMeta Connection Complete event. The 12 bits that make up the connection_handle are not contiguous - see also https://github.com/blue-heron/blue_heron/pull/72.