### PR TITLE
Fix initialization

### DIFF
--- a/lib/blue_heron/hci/transport.ex
+++ b/lib/blue_heron/hci/transport.ex
@@ -187,7 +187,7 @@ defmodule BlueHeron.HCI.Transport do
     case module.send_command(pid, command) do
       true ->
         Logger.hci_packet(:HCI_COMMAND_DATA_PACKET, :out, command)
-        {:keep_state, %{data | init_commands: rest}, []}
+        prepare(:internal, :init, %{data | init_commands: rest})
 
       false ->
         Logger.error("Init command: #{inspect(command)} failed")


### PR DESCRIPTION
This PR fixes a couple issues I ran into when trying to run the [`scanner.ex`](https://github.com/blue-heron/blue_heron/blob/main/examples/scanner.ex) example with a [Realtek rtl8761b](https://www.amazon.com/dp/B08CMP5LQC?psc=1&ref=ppx_yo2_dt_b_product_details) USB dongle (VID=`0x0BDA`, PID=`0x8771`). On initialization of the Bluetooth dongle the GenServer would timeout:

```text
iex(1)> {:ok, pid} = BlueHeronScan.start_link(:usb, %{pid: 0x8771})

15:27:30.955 [warning] BlueHeron(USB): Using BT device at bus 3, device 8: ID 0bda:8771
{:ok, #PID<0.284.0>}
iex(2)> 
15:27:35.952 [error] Timeout executing Init commands
 
15:27:40.953 [error] Timeout executing Init commands
 
15:27:45.955 [error] Timeout executing Init commands
** (EXIT from #PID<0.282.0>) shell process exited with reason: :reached_max_error
```

The first place seems to be from `{:next_event, :internal, :init}` not getting emitted after each `prepare()` completed (26eaf58). The second looks like it was from the `send_command()` call not receiving a reply (ea4a51c).

Versions:

```text
elixir          1.13.3-otp-24
erlang          24.3.1
```

Kernel:

```text
Linux ubuntu 5.13.0-35-generic
```