### PR TITLE
gatt: Allow configure permissions

### DIFF
--- a/lib/blue_heron/att/responses/error_response.ex
+++ b/lib/blue_heron/att/responses/error_response.ex
@@ -5,6 +5,7 @@ defmodule BlueHeron.ATT.ErrorResponse do
     <<0x01, request_opcode, handle::little-16, serialize_error(error)>>
   end
 
+  defp serialize_error(:insufficient_authentication), do: 0x05
   defp serialize_error(:attribute_not_found), do: 0x0A
 
   def deserialize(<<0x01, request_opcode, handle::little-16, error>>) do
@@ -16,6 +17,7 @@ defmodule BlueHeron.ATT.ErrorResponse do
     }
   end
 
+  defp deserialize_error(0x05), do: :insufficient_authentication
   defp deserialize_error(0x0A), do: :attribute_not_found
   defp deserialize_error(code), do: code
 end

--- a/lib/blue_heron/gatt/characteristic.ex
+++ b/lib/blue_heron/gatt/characteristic.ex
@@ -9,13 +9,23 @@ defmodule BlueHeron.GATT.Characteristic do
             id: id,
             type: non_neg_integer(),
             properties: non_neg_integer(),
+            permissions: nil | list(),
             descriptor: nil | map(),
             handle: any(),
             value_handle: any(),
             descriptor_handle: any()
           }
 
-  defstruct [:id, :type, :properties, :descriptor, :handle, :value_handle, :descriptor_handle]
+  defstruct [
+    :id,
+    :type,
+    :properties,
+    :permissions,
+    :descriptor,
+    :handle,
+    :value_handle,
+    :descriptor_handle
+  ]
 
   @doc """
   Create a characteristic with fields taken from the map `args`.
@@ -31,13 +41,14 @@ defmodule BlueHeron.GATT.Characteristic do
       iex> BlueHeron.GATT.Characteristic.new(%{
       ...>   id: :fancy_key,
       ...>   type: 0x2e0f8e717a7d4690998377626bc6b657,
-      ...>   properties: 0b00000010
+      ...>   properties: 0b00000010,
+      ...>   permissions: [:write]
       ...> })
       %BlueHeron.GATT.Characteristic{id: :fancy_key, type: 0x2e0f8e717a7d4690998377626bc6b657, properties: 2}
   """
   @spec new(args :: map()) :: t()
   def new(args) do
-    args = Map.take(args, [:id, :type, :properties, :descriptor])
+    args = Map.take(args, [:id, :type, :properties, :permissions, :descriptor])
     struct!(__MODULE__, args)
   end
 end


### PR DESCRIPTION
This change adds permission configuration to GATT characteristics. The permissions. If permissions are required a error response is returned.

This change does not implement pairing, bonding or authentication.

Signed-off-by: Markus Hutzler <markus@keeplabs.com>