### PR TITLE
smp: Add Security Manager Protocol Module

### DIFF
--- a/lib/blue_heron/gatt/server.ex
+++ b/lib/blue_heron/gatt/server.ex
@@ -86,6 +86,7 @@ defmodule BlueHeron.GATT.Server do
   }
 
   alias BlueHeron.GATT.{Characteristic, Service}
+  alias BlueHeron.SMP
 
   @doc """
   Return the list of services that make up the GATT profile of the device.
@@ -230,7 +231,7 @@ defmodule BlueHeron.GATT.Server do
           write_long_characteristic_value(state, request)
         end
 
-      request ->
+      _ ->
         # Ignore unhandled requests
         {state, nil}
     end
@@ -318,13 +319,16 @@ defmodule BlueHeron.GATT.Server do
   end
 
   defp require_permission?(state, request, permission) do
-    # TODO: return false if authentication is required and established
     p_list = find_characteristic_permissions(state.profile, request.handle)
 
-    if permission in p_list do
-      true
-    else
+    if p_list == nil do
       false
+    else
+      if permission in p_list and not SMP.is_authenticated?() do
+        true
+      else
+        false
+      end
     end
   end
 

--- a/lib/blue_heron/hci/command.ex
+++ b/lib/blue_heron/hci/command.ex
@@ -21,6 +21,8 @@ defmodule BlueHeron.HCI.Command do
     ControllerAndBaseband.WriteSimplePairingMode,
     ControllerAndBaseband.WriteSynchronousFlowControlEnable,
     InformationalParameters.ReadLocalVersion,
+    InformationalParameters.ReadLocalSupportedCommands,
+    InformationalParameters.ReadBRADDR,
     LEController.CreateConnection,
     LEController.CreateConnectionCancel,
     LEController.ReadBufferSizeV1,
@@ -31,6 +33,8 @@ defmodule BlueHeron.HCI.Command do
     LEController.SetRandomAddress,
     LEController.SetScanEnable,
     LEController.SetScanParameters,
+    LEController.LongTermKeyRequestReply,
+    LEController.LongTermKeyRequestNegativeReply,
     LinkPolicy.WriteDefaultLinkPolicySettings
   ]
 

--- a/lib/blue_heron/hci/commands/informational_parameters/read_bd_addr.ex
+++ b/lib/blue_heron/hci/commands/informational_parameters/read_bd_addr.ex
@@ -1,0 +1,29 @@
+defmodule BlueHeron.HCI.Command.InformationalParameters.ReadBRADDR do
+  use BlueHeron.HCI.Command.InformationalParameters, ocf: 0x0009
+
+  defparameters []
+
+  defimpl BlueHeron.HCI.Serializable do
+    def serialize(rlv) do
+      <<rlv.opcode::binary, 0>>
+    end
+  end
+
+  @impl BlueHeron.HCI.Command
+  def deserialize(<<@opcode::binary, 0>>) do
+    %__MODULE__{}
+  end
+
+  @impl BlueHeron.HCI.Command
+  def deserialize_return_parameters(<<status, addr::little-unsigned-integer-size(48)>>) do
+    %{
+      status: status,
+      bd_addr: BlueHeron.Address.parse(addr)
+    }
+  end
+
+  @impl BlueHeron.HCI.Command
+  def serialize_return_parameters(%{status: status} = params) do
+    <<status>> <> params.bd_addr.binary()
+  end
+end

--- a/lib/blue_heron/hci/commands/informational_parameters/read_local_supported_commands.ex
+++ b/lib/blue_heron/hci/commands/informational_parameters/read_local_supported_commands.ex
@@ -1,0 +1,29 @@
+defmodule BlueHeron.HCI.Command.InformationalParameters.ReadLocalSupportedCommands do
+  use BlueHeron.HCI.Command.InformationalParameters, ocf: 0x0002
+
+  defparameters []
+
+  defimpl BlueHeron.HCI.Serializable do
+    def serialize(rlv) do
+      <<rlv.opcode::binary, 0>>
+    end
+  end
+
+  @impl BlueHeron.HCI.Command
+  def deserialize(<<@opcode::binary, 0>>) do
+    %__MODULE__{}
+  end
+
+  @impl BlueHeron.HCI.Command
+  def deserialize_return_parameters(<<status, bin::binary>>) do
+    %{
+      status: status,
+      supported_commands: bin
+    }
+  end
+
+  @impl BlueHeron.HCI.Command
+  def serialize_return_parameters(%{status: status} = params) do
+    <<status>> <> params.supported_commands
+  end
+end

--- a/lib/blue_heron/hci/commands/le_controller/long_term_key_request_negative_reply.ex
+++ b/lib/blue_heron/hci/commands/le_controller/long_term_key_request_negative_reply.ex
@@ -1,0 +1,35 @@
+defmodule BlueHeron.HCI.Command.LEController.LongTermKeyRequestNegativeReply do
+  use BlueHeron.HCI.Command.LEController, ocf: 0x001B
+
+  defparameters [
+    :status,
+    :connection_handle
+  ]
+
+  defimpl BlueHeron.HCI.Serializable do
+    def serialize(%{opcode: opcode, connection_handle: handle}) do
+      <<opcode::binary, 2, handle::little-16>>
+    end
+  end
+
+  @impl BlueHeron.HCI.Command
+  def deserialize(<<@opcode::binary, 2, lower_handle, _::4, upper_handle::4>>) do
+    <<handle::little-12>> = <<lower_handle, upper_handle::4>>
+
+    %__MODULE__{
+      opcode: @opcode,
+      connection_handle: handle
+    }
+  end
+
+  @impl BlueHeron.HCI.Command
+  def deserialize_return_parameters(<<status, lower_handle, _::4, upper_handle::4>>) do
+    <<handle::little-12>> = <<lower_handle, upper_handle::4>>
+    %{status: status, connection_handle: handle}
+  end
+
+  @impl BlueHeron.HCI.Command
+  def serialize_return_parameters(%{status: status, connection_handle: handle}) do
+    <<BlueHeron.ErrorCode.to_code!(status), handle::little-16>>
+  end
+end

--- a/lib/blue_heron/hci/commands/le_controller/long_term_key_request_reply.ex
+++ b/lib/blue_heron/hci/commands/le_controller/long_term_key_request_reply.ex
@@ -1,0 +1,37 @@
+defmodule BlueHeron.HCI.Command.LEController.LongTermKeyRequestReply do
+  use BlueHeron.HCI.Command.LEController, ocf: 0x001A
+
+  defparameters [
+    :connection_handle,
+    :ltk
+  ]
+
+  defimpl BlueHeron.HCI.Serializable do
+    def serialize(%{opcode: opcode, connection_handle: handle, ltk: ltk}) do
+      bin = <<handle::little-16>> <> ltk
+      <<opcode::binary, 18, bin::binary>>
+    end
+  end
+
+  @impl BlueHeron.HCI.Command
+  def deserialize(<<@opcode::binary, 18, lower_handle, _::4, upper_handle::4, ltk::binary>>) do
+    <<handle::little-12>> = <<lower_handle, upper_handle::4>>
+
+    %__MODULE__{
+      opcode: @opcode,
+      connection_handle: handle,
+      ltk: ltk
+    }
+  end
+
+  @impl BlueHeron.HCI.Command
+  def deserialize_return_parameters(<<status, lower_handle, _::4, upper_handle::4>>) do
+    <<handle::little-12>> = <<lower_handle, upper_handle::4>>
+    %{status: status, connection_handle: handle}
+  end
+
+  @impl BlueHeron.HCI.Command
+  def serialize_return_parameters(%{status: status, connection_handle: handle}) do
+    <<BlueHeron.ErrorCode.to_code!(status), handle::little-16>>
+  end
+end

--- a/lib/blue_heron/hci/commands/link_control/authentication_requested.ex
+++ b/lib/blue_heron/hci/commands/link_control/authentication_requested.ex
@@ -1,0 +1,45 @@
+defmodule BlueHeron.HCI.Command.LinkControl.AuthenticationRequested do
+  use BlueHeron.HCI.Command.LinkControl, ocf: 0x0011
+
+  @moduledoc """
+  This command is used to try to authenticate the remote device associated with
+  the specified Connection_Handle.
+
+  * OGF: `#{inspect(@ogf, base: :hex)}`
+  * OCF: `#{inspect(@ocf, base: :hex)}`
+  * Opcode: `#{inspect(@opcode)}`
+
+  Bluetooth Spec v5.3, Vol 4, Part E, section 7.1.15
+
+  ## Command Parameters
+  * `handle` - Connection handle
+
+  ## Return Parameters
+  * `:status` - see `BlueHeron.ErrorCode`
+  """
+
+  defparameters handle: 0
+
+  defimpl BlueHeron.HCI.Serializable do
+    def serialize(%{opcode: opcode, handle: handle}) do
+      bin = <<handle::little-16>>
+      size = byte_size(bin)
+      <<opcode::binary, size, bin::binary>>
+    end
+  end
+
+  @impl BlueHeron.HCI.Command
+  def deserialize(<<@opcode::binary, 0>>) do
+    %__MODULE__{}
+  end
+
+  @impl BlueHeron.HCI.Command
+  def deserialize_return_parameters(<<>>) do
+    %{}
+  end
+
+  @impl true
+  def serialize_return_parameters(%{}) do
+    <<>>
+  end
+end

--- a/lib/blue_heron/hci/commands/link_control/set_connection_encryption.ex
+++ b/lib/blue_heron/hci/commands/link_control/set_connection_encryption.ex
@@ -1,0 +1,48 @@
+defmodule BlueHeron.HCI.Command.LinkControl.SetConnectionEncryption do
+  use BlueHeron.HCI.Command.LinkControl, ocf: 0x0013
+
+  @moduledoc """
+  This command is used to try to authenticate the remote device associated with
+  the specified Connection_Handle.
+
+  * OGF: `#{inspect(@ogf, base: :hex)}`
+  * OCF: `#{inspect(@ocf, base: :hex)}`
+  * Opcode: `#{inspect(@opcode)}`
+
+  Bluetooth Spec v5.3, Vol 4, Part E, section 7.1.16
+
+  ## Command Parameters
+  * `handle` - Connection handle
+
+  ## Return Parameters
+  * `:status` - see `BlueHeron.ErrorCode`
+  """
+
+  defparameters handle: 0, enable: true
+
+  defimpl BlueHeron.HCI.Serializable do
+    def serialize(%{opcode: opcode, handle: handle, enable: enable}) do
+      bin = <<handle::little-16, as_uint8(enable)>>
+      size = byte_size(bin)
+      <<opcode::binary, size, bin::binary>>
+    end
+
+    defp as_uint8(true), do: 1
+    defp as_uint8(false), do: 0
+  end
+
+  @impl BlueHeron.HCI.Command
+  def deserialize(<<@opcode::binary, 0>>) do
+    %__MODULE__{}
+  end
+
+  @impl BlueHeron.HCI.Command
+  def deserialize_return_parameters(<<>>) do
+    %{}
+  end
+
+  @impl true
+  def serialize_return_parameters(%{}) do
+    <<>>
+  end
+end

--- a/lib/blue_heron/hci/event.ex
+++ b/lib/blue_heron/hci/event.ex
@@ -25,12 +25,15 @@ defmodule BlueHeron.HCI.Event do
   alias BlueHeron.HCI.Event
 
   @modules [
+    Event.EncryptionChange,
     Event.CommandComplete,
     Event.CommandStatus,
+    Event.NumberOfCompletedPackets,
     Event.DisconnectionComplete,
     Event.InquiryComplete,
     Event.LEMeta.AdvertisingReport,
-    Event.LEMeta.ConnectionComplete
+    Event.LEMeta.ConnectionComplete,
+    Event.LEMeta.LongTermKeyRequest
   ]
 
   def __modules__(), do: @modules

--- a/lib/blue_heron/hci/events/encryption_change.ex
+++ b/lib/blue_heron/hci/events/encryption_change.ex
@@ -1,0 +1,55 @@
+defmodule BlueHeron.HCI.Event.EncryptionChange do
+  use BlueHeron.HCI.Event, code: 0x08
+
+  @moduledoc """
+  The HCI_Encryption_Change event is used to indicate that the change of the
+  encryption mode has been completed. The Connection_Handle event
+  parameter will be a Connection_Handle for an ACL connection and is used to
+  identify the remote device.
+
+  Reference: Version 5.4, Vol 4, Part E, 7.7.8
+  """
+
+  defparameters [
+    :status,
+    :connection_handle,
+    :encryption_enabled
+  ]
+
+  defimpl BlueHeron.HCI.Serializable do
+    def serialize(data) do
+      <<lower_handle, upper_handle::4>> = <<data.connection_handle::little-12>>
+      handle = <<lower_handle, 0::4, upper_handle::4>>
+
+      bin = <<
+        data.status,
+        handle::binary,
+        data.encryption_enabled
+      >>
+
+      size = byte_size(bin)
+      <<data.code, size, bin::binary>>
+    end
+  end
+
+  @impl BlueHeron.HCI.Event
+  def deserialize(<<@code, _size, bin::binary>>) do
+    <<
+      status,
+      lower_handle,
+      _::4,
+      upper_handle::4,
+      encryption_enabled
+    >> = bin
+
+    <<handle::little-12>> = <<lower_handle, upper_handle::4>>
+
+    %__MODULE__{
+      status: status,
+      connection_handle: handle,
+      encryption_enabled: encryption_enabled
+    }
+  end
+
+  def deserialize(bin), do: {:error, bin}
+end

--- a/lib/blue_heron/hci/events/le_meta/long_term_key_request.ex
+++ b/lib/blue_heron/hci/events/le_meta/long_term_key_request.ex
@@ -1,0 +1,59 @@
+defmodule BlueHeron.HCI.Event.LEMeta.LongTermKeyRequest do
+  use BlueHeron.HCI.Event.LEMeta, subevent_code: 0x05
+
+  @moduledoc """
+  The HCI_LE_Long_Term_Key_Request event indicates that the peer device, in
+  the Central role, is attempting to encrypt or re-encrypt the link and is requesting
+  the Long Term Key from the Host. (See [Vol 6] Part B, Section 5.1.3).
+
+  Reference: Version 5.3, Vol 4, Part E, 7.7.65.5
+  """
+
+  defparameters [
+    :subevent_code,
+    :connection_handle,
+    :random_number,
+    :encrypted_diversifier
+  ]
+
+  defimpl BlueHeron.HCI.Serializable do
+    def serialize(data) do
+      <<lower_handle, upper_handle::4>> = <<data.connection_handle::little-12>>
+      handle = <<lower_handle, 0::4, upper_handle::4>>
+
+      bin = <<
+        data.subevent_code,
+        data.status,
+        handle::binary,
+        data.random_number::little-64,
+        data.encrypted_diversifier::little-16
+      >>
+
+      size = byte_size(bin)
+
+      <<data.code, size, bin::binary>>
+    end
+  end
+
+  @impl BlueHeron.HCI.Event
+  def deserialize(<<@code, _size, @subevent_code, bin::binary>>) do
+    <<
+      lower_handle,
+      _::4,
+      upper_handle::4,
+      random_number::little-64,
+      encrypted_diversifier::little-16
+    >> = bin
+
+    <<handle::little-12>> = <<lower_handle, upper_handle::4>>
+
+    %__MODULE__{
+      subevent_code: @subevent_code,
+      connection_handle: handle,
+      random_number: random_number,
+      encrypted_diversifier: encrypted_diversifier
+    }
+  end
+
+  def deserialize(bin), do: {:error, bin}
+end

--- a/lib/blue_heron/hci/events/number_of_completed_packets.ex
+++ b/lib/blue_heron/hci/events/number_of_completed_packets.ex
@@ -1,0 +1,35 @@
+defmodule BlueHeron.HCI.Event.NumberOfCompletedPackets do
+  use BlueHeron.HCI.Event, code: 0x13
+
+  @moduledoc """
+  > The HCI_Number_Of_Completed_Packets event is used by the Controller to
+  > indicate to the Host how many HCI Data packets have been completed for
+  > each Connection_Handle since the previous HCI_Number_Of_Completed_-
+  > Packets event was sent to the Host.
+
+  Reference: Version 5.3, Vol 4, Part E, 7.7.19
+  """
+
+  require Logger
+
+  defparameters [:num_handles, :data]
+
+  defimpl BlueHeron.HCI.Serializable do
+    def serialize(data) do
+      bin = <<data.num_handles, data.data::binary>>
+      size = byte_size(bin)
+      <<data.code, size, bin::binary>>
+    end
+  end
+
+  @impl BlueHeron.HCI.Event
+  def deserialize(<<@code, _size, num_handles, data::binary>>) do
+    # TODO: deserialize data
+    %__MODULE__{
+      num_handles: num_handles,
+      data: data
+    }
+  end
+
+  def deserialize(bin), do: {:error, bin}
+end

--- a/lib/blue_heron/hci_dump/logger.ex
+++ b/lib/blue_heron/hci_dump/logger.ex
@@ -113,6 +113,8 @@ defmodule BlueHeron.HCIDump.Logger do
       pktlog = %PKTLOG{type: unquote(type), payload: unquote(payload)}
       encoded = HCIDump.encode(%PKTLOG{pktlog | tv_sec: ts, tv_us: usec}, unquote(direction))
 
+      # Logger.log(:debug, "pkg: #{unquote(direction)} #{unquote(type)} #{inspect(pktlog)}")
+
       with true <- Application.get_env(:blue_heron, :log_hci_dump_file, true),
            :ok <- File.write("/tmp/hcidump.pklg", encoded, [:append]) do
         :ok

--- a/lib/blue_heron/peripheral.ex
+++ b/lib/blue_heron/peripheral.ex
@@ -7,22 +7,39 @@ defmodule BlueHeron.Peripheral do
     SetAdvertisingEnable
   }
 
-  alias BlueHeron.HCI.Command.LinkControl.Disconnect
+  alias BlueHeron.HCI.Command.LinkControl.{
+    AuthenticationRequested,
+    SetConnectionEncryption,
+    Disconnect
+  }
 
-  alias BlueHeron.HCI.Event.{CommandComplete, CommandStatus, DisconnectionComplete}
-  alias BlueHeron.HCI.Event.LEMeta.ConnectionComplete
+  alias BlueHeron.HCI.Event.{
+    CommandComplete,
+    CommandStatus,
+    NumberOfCompletedPackets,
+    DisconnectionComplete,
+    EncryptionChange
+  }
+
+  alias BlueHeron.HCI.Event.LEMeta.{ConnectionComplete, LongTermKeyRequest}
 
   alias BlueHeron.{ACL, L2Cap}
 
   alias BlueHeron.GATT
   alias BlueHeron.GATT.{Characteristic, Service}
 
+  alias BlueHeron.SMP
+
   @behaviour :gen_statem
 
-  defstruct [:ctx, :controlling_process, :gatt_handler, :conn_handle, :gatt_server]
+  defstruct [:ctx, :bd_addr, :controlling_process, :gatt_handler, :gatt_server, :connection, :smp]
 
   def start_link(context, gatt_server) do
-    :gen_statem.start_link(__MODULE__, [context, gatt_server, self()], [])
+    :gen_statem.start_link(__MODULE__, [context, "/tmp/ble_keyfile", gatt_server, self()], [])
+  end
+
+  def start_link(context, keyfile, gatt_server) do
+    :gen_statem.start_link(__MODULE__, [context, keyfile, gatt_server, self()], [])
   end
 
   def set_advertising_parameters(pid, params) do
@@ -68,13 +85,15 @@ defmodule BlueHeron.Peripheral do
   def callback_mode(), do: :state_functions
 
   @impl :gen_statem
-  def init([ctx, gatt_handler, controlling_process]) do
+  def init([ctx, keyfile, gatt_handler, controlling_process]) do
     :ok = BlueHeron.add_event_handler(ctx)
+    {:ok, smp} = SMP.start_link(ctx, keyfile)
 
     data = %__MODULE__{
       controlling_process: controlling_process,
       ctx: ctx,
-      gatt_handler: gatt_handler
+      gatt_handler: gatt_handler,
+      smp: smp
     }
 
     {:ok, :wait_working, data, []}
@@ -117,6 +136,12 @@ defmodule BlueHeron.Peripheral do
     {:next_state, :advertising, data, [{:reply, from, :ok}]}
   end
 
+  def ready(:info, {:HCI_EVENT_PACKET, %CommandComplete{opcode: <<9, 16>>} = event}, data) do
+    # Response from reading BD_ADDRESS
+    SMP.set_bd_address(event.return_parameters.bd_addr)
+    {:next_state, :ready, %{data | bd_addr: event.return_parameters.bd_addr}}
+  end
+
   def ready(:info, {:HCI_EVENT_PACKET, _event}, _data) do
     :keep_state_and_data
   end
@@ -135,8 +160,14 @@ defmodule BlueHeron.Peripheral do
     Logger.info("Peripheral connect #{event.connection_handle}")
     gatt_server = GATT.Server.init(data.gatt_handler)
 
-    {:next_state, :connected,
-     %{data | gatt_server: gatt_server, conn_handle: event.connection_handle}}
+    connection = %{
+      peer_address: event.peer_address,
+      peer_address_type: event.peer_address_type,
+      handle: event.connection_handle
+    }
+
+    SMP.set_connection(connection)
+    {:next_state, :connected, %{data | gatt_server: gatt_server, connection: connection}}
   end
 
   def advertising(:info, {:HCI_EVENT_PACKET, _event}, _data) do
@@ -144,8 +175,12 @@ defmodule BlueHeron.Peripheral do
     :keep_state_and_data
   end
 
+  def advertising({:call, from}, :authenticate, _data) do
+    {:keep_state_and_data, {:reply, from, {:error, :not_connected}}}
+  end
+
   def connected({:call, from}, :disconnect, data) do
-    command = Disconnect.new(connection_handle: data.conn_handle)
+    command = Disconnect.new(connection_handle: data.connection.handle)
     {:ok, %CommandStatus{status: 0x00}} = BlueHeron.hci_command(data.ctx, command)
     {:keep_state_and_data, {:reply, from, :ok}}
   end
@@ -165,7 +200,7 @@ defmodule BlueHeron.Peripheral do
 
     case notif do
       {:ok, result} ->
-        acl = build_l2cap_acl(data.conn_handle, result)
+        acl = build_l2cap_acl(data.connection.handle, 0x0004, result)
 
         Logger.info(%{notif_acl: acl})
 
@@ -179,7 +214,7 @@ defmodule BlueHeron.Peripheral do
 
   def connected({:call, from}, {:exchange_mtu, server_mtu}, data) do
     {:ok, request} = GATT.Server.exchange_mtu(data.gatt_server, server_mtu)
-    acl = build_l2cap_acl(data.conn_handle, request)
+    acl = build_l2cap_acl(data.connection.handle, 0x0004, request)
     r = BlueHeron.acl(data.ctx, acl)
     {:keep_state_and_data, {:reply, from, r}}
   end
@@ -187,13 +222,13 @@ defmodule BlueHeron.Peripheral do
   def connected(
         :info,
         {:HCI_ACL_DATA_PACKET, %ACL{handle: handle, data: %L2Cap{cid: 0x0004, data: request}}},
-        %{conn_handle: _handle} = data
+        data
       ) do
     Logger.info("Peripheral service discovery request: #{handle}=> #{inspect(request)}")
     {gatt_server, response} = GATT.Server.handle(data.gatt_server, request)
 
     if response do
-      acl_response = build_l2cap_acl(handle, response)
+      acl_response = build_l2cap_acl(handle, 0x0004, response)
       Process.sleep(100)
       BlueHeron.acl(data.ctx, acl_response)
     end
@@ -201,15 +236,31 @@ defmodule BlueHeron.Peripheral do
     {:keep_state, %{data | gatt_server: gatt_server}, []}
   end
 
+  def connected(
+        :info,
+        {:HCI_ACL_DATA_PACKET, %ACL{handle: handle, data: %L2Cap{cid: 0x0006, data: request}}},
+        data
+      ) do
+    response = SMP.handle(request)
+
+    if response do
+      acl_response = build_l2cap_acl(handle, 0x0006, response)
+      Process.sleep(100)
+      BlueHeron.acl(data.ctx, acl_response)
+    end
+
+    {:keep_state, data, []}
+  end
+
   def connected(:info, {:HCI_ACL_DATA_PACKET, acl}, data) do
     Logger.info("Unhandled ACL packet: #{inspect(acl)} #{inspect(data)}")
     :keep_state_and_data
   end
 
-  def connected(:info, {:HCI_EVENT_PACKET, %DisconnectionComplete{}}, data) do
+  def connected(:info, {:HCI_EVENT_PACKET, %DisconnectionComplete{} = pkg}, data) do
     send(data.controlling_process, {__MODULE__, :disconnected})
-    Logger.warn("Peripheral Disconnect #{data.conn_handle}")
-    {:next_state, :ready, %{data | gatt_server: nil, conn_handle: nil}}
+    Logger.warn("Peripheral Disconnect #{inspect(pkg.reason)}")
+    {:next_state, :ready, %{data | gatt_server: nil, connection: nil}}
   end
 
   def connected(:info, {:HCI_EVENT_PACKET, %CommandStatus{opcode: <<0x0406::little-16>>}}, _data) do
@@ -217,12 +268,47 @@ defmodule BlueHeron.Peripheral do
     :keep_state_and_data
   end
 
-  defp build_l2cap_acl(handle, payload) do
+  def connected(
+        :info,
+        {:HCI_EVENT_PACKET, %CommandComplete{return_parameters: %{status: 0}}},
+        _data
+      ) do
+    # Ignore the notification that is generated when a command is executed with success
+    :keep_state_and_data
+  end
+
+  def connected(:info, {:HCI_EVENT_PACKET, %NumberOfCompletedPackets{}}, _data) do
+    # We still receive HCI_Number_Of_Completed_Packet events, ignore... (Flow
+    # control is disabled)
+    :keep_state_and_data
+  end
+
+  def connected(:info, {:HCI_EVENT_PACKET, %LongTermKeyRequest{} = request}, data) do
+    command = SMP.long_term_key_request(request)
+
+    if command do
+      BlueHeron.hci_command(data.ctx, command)
+    end
+
+    {:keep_state, data, []}
+  end
+
+  def connected(:info, {:HCI_EVENT_PACKET, %EncryptionChange{} = request}, data) do
+    SMP.encryption_change(request)
+    {:keep_state, data, []}
+  end
+
+  def connected(:info, pkg, _data) do
+    Logger.warn("Unhandled packet: #{inspect(pkg)}")
+    :keep_state_and_data
+  end
+
+  defp build_l2cap_acl(handle, cid, payload) do
     %ACL{
       handle: handle,
       flags: %{bc: 0, pb: 0},
       data: %L2Cap{
-        cid: 0x0004,
+        cid: cid,
         data: payload
       }
     }

--- a/lib/blue_heron/smp.ex
+++ b/lib/blue_heron/smp.ex
@@ -1,0 +1,403 @@
+defmodule BlueHeron.SMP do
+  @moduledoc """
+  A behaviour module for implementing BLE Security Manager Protocol.
+  """
+
+  use GenServer
+
+  require Logger
+
+  alias BlueHeron.HCI.Command.LEController.{
+    LongTermKeyRequestReply,
+    LongTermKeyRequestNegativeReply
+  }
+
+  alias BlueHeron.{ACL, L2Cap}
+  alias BlueHeron.SMP.Keys
+
+  defstruct [
+    :ctx,
+    :pairing,
+    :bd_address,
+    :connection,
+    :stk_used,
+    :authenticated
+  ]
+
+  @doc false
+  def start_link(ctx, keyfile) do
+    GenServer.start_link(__MODULE__, [ctx, keyfile], name: __MODULE__)
+  end
+
+  @doc false
+  @impl GenServer
+  def init([ctx, keyfile]) do
+    Elixir.BlueHeron.SMP.Keys.start(keyfile)
+    {:ok, %__MODULE__{ctx: ctx, authenticated: false}}
+  end
+
+  @doc "Set BR_ADDR."
+  def set_bd_address(addr) do
+    GenServer.cast(__MODULE__, {:set_bd_address, addr})
+  end
+
+  @doc """
+  Returns true if the current connection is authenticated.
+  """
+  def is_authenticated?() do
+    GenServer.call(__MODULE__, :is_authenticated)
+  end
+
+  @doc """
+  Set connection information.
+
+  The information is needed for key generation.
+  """
+  def set_connection(con) do
+    GenServer.cast(__MODULE__, {:set_connection, con})
+  end
+
+  @doc """
+  Handle Long Term Key Request event.
+
+  This function returns a Long Term Key Request Response or nil.
+  """
+  def long_term_key_request(msg) do
+    GenServer.call(__MODULE__, {:long_term_key_request, msg})
+  end
+
+  @doc """
+  Inform the Security Manager about changes in the encryption.
+  """
+  def encryption_change(event) do
+    GenServer.call(__MODULE__, {:encryption_change, event})
+  end
+
+  def handle(msg) do
+    GenServer.call(__MODULE__, {:handle, msg})
+  end
+
+  @impl GenServer
+  def handle_cast({:set_bd_address, addr}, state) do
+    {:noreply, %{state | bd_address: addr}}
+  end
+
+  def handle_cast({:set_connection, con}, state) do
+    {:noreply, %{state | connection: con, authenticated: false}}
+  end
+
+  @impl GenServer
+  def handle_call(:is_authenticated, _from, state) do
+    {:reply, state.authenticated, state}
+  end
+
+  def handle_call({:handle, <<0x01, data::binary>>}, _from, state) do
+    # Pairing Request
+    <<_io, _obb, _auth, max_key, _idist, _rdist>> = data
+
+    # TODO: Filter requests not matching parameters
+    # Check max_key = 16
+
+    passkey = :rand.uniform(999_999)
+
+    message =
+      passkey
+      |> Integer.to_string()
+      |> String.pad_leading(6, "0")
+
+    # TODO: inform caller to show passkey on display # callback(random)
+    # callback: pairing({status: :progress, passkey: message})
+    Logger.info("=================== #{message} ===================")
+
+    k = <<passkey::integer-size(128)>>
+    r = :crypto.strong_rand_bytes(16)
+    response = <<0x02, 0x01, 0x00, 0b00000101, 16, 0x0F, 0x0F>>
+
+    # Set up all pairing related information
+    pairing = %{
+      pres: reverse(response),
+      preq: reverse(<<0x01>> <> data),
+      k: k,
+      ir: nil,
+      r: r,
+      confirm: nil
+    }
+
+    {:reply, response, %{state | pairing: pairing, authenticated: false}}
+  end
+
+  def handle_call({:handle, <<0x02, _data::binary>>}, _from, state) do
+    # Pairing Response
+    Logger.warning("Ignoring Handle Pairing Response")
+    response = nil
+    {:reply, response, state}
+  end
+
+  def handle_call({:handle, <<0x03, confirm::binary>>}, _from, state) do
+    # Handle Pairing Confirm
+
+    pairing = %{state.pairing | confirm: reverse(confirm)}
+    ia = BlueHeron.Address.parse(state.connection.peer_address).binary()
+    iat = state.connection.peer_address_type
+    ra = state.bd_address.binary()
+    rat = 0
+
+    response = c1(pairing.k, pairing.r, pairing.preq, pairing.pres, iat, rat, ia, ra)
+    {:reply, <<0x03>> <> reverse(response), %{state | pairing: pairing}}
+  end
+
+  def handle_call({:handle, <<0x04, random::binary>>}, _from, state) do
+    # Handle Pairing Random
+
+    pairing = %{state.pairing | ir: reverse(random)}
+    ia = BlueHeron.Address.parse(state.connection.peer_address).binary()
+    iat = state.connection.peer_address_type
+    ra = state.bd_address.binary()
+    rat = 0
+
+    # Use c1() with peer random
+    response = c1(pairing.k, pairing.ir, pairing.preq, pairing.pres, iat, rat, ia, ra)
+
+    # Is confirmed?
+    if pairing.confirm == response do
+      # TODO: Inform Box UI that pairing completed
+      # callback: pairing({status: :success})
+      {:reply, <<0x04>> <> reverse(pairing.r), %{state | pairing: pairing}}
+    else
+      Logger.warning("passkey missmatch")
+      # TODO: Inform Box UI that pairing failed
+      # callback: pairing({status: :failed})
+
+      {:reply, <<0x05, 0x04>>, %{state | pairing: nil}}
+    end
+  end
+
+  def handle_call({:handle, <<0x05, reason>>}, _from, state) do
+    Logger.warn("Pairing failed: #{reason}")
+    # TODO: Inform Box UI that pairing failed
+    # callback: pairing({status: :failed})
+    {:reply, nil, state}
+  end
+
+  def handle_call({:handle, <<0x06, _ltk::binary>>}, _from, state) do
+    # Got LTK from central. We will not use it, it will connect to us in the future.
+    {:reply, nil, state}
+  end
+
+  def handle_call(
+        {:handle, <<0x07, _ediv::little-16, _rand::little-64>>},
+        _from,
+        state
+      ) do
+    # Got EDIV and Rand from central. We will not use it, it will connect to us in the future.
+    {:reply, nil, state}
+  end
+
+  def handle_call({:handle, <<0x0A, _csrk::binary>>}, _from, state) do
+    # Got CSRK from central. We will not use it, it will connect to us in the future.
+    {:reply, nil, state}
+  end
+
+  def handle_call({:handle, msg}, _from, state) do
+    Logger.warning("Unknown SMP request: #{inspect(msg)}")
+    {:reply, nil, state}
+  end
+
+  def handle_call({:long_term_key_request, %{encrypted_diversifier: 0} = request}, _from, state) do
+    # EDIV is 0 we use STK as a encryption key
+
+    stk = s1(state.pairing.k, state.pairing.r, state.pairing.ir)
+
+    command =
+      LongTermKeyRequestReply.new(
+        connection_handle: request.connection_handle,
+        ltk: reverse(stk)
+      )
+
+    {:reply, command, %{state | stk_used: true}}
+  end
+
+  def handle_call({:long_term_key_request, request}, _from, state) do
+    # TODO: Handle unknown EDIV
+    {ediv, keys} = Keys.get(request.encrypted_diversifier)
+
+    command = reply_for_ltk_request(request, ediv, keys)
+    {:reply, command, %{state | stk_used: false}}
+  end
+
+  def handle_call({:encryption_change, event}, _from, %{stk_used: true} = state) do
+    # We got an encrypted channel, but we only used the short term key lets exchange keys
+
+    # We are using the DATABASE LOOKUP described in the Bluetooth pecification
+    # Version 5.3 | Vol 3, Part H Appendix B1
+    {ediv,
+     <<
+       rand::bytes-size(8),
+       ltk::bytes-size(16),
+       csrk::bytes-size(16),
+       irk::bytes-size(16)
+     >>} = Keys.new()
+
+    # generate and send LTK using "Encryption Information" ACL message
+    frame = acl(event.connection_handle, <<0x06>> <> reverse(ltk))
+    BlueHeron.acl(state.ctx, frame)
+    :timer.sleep(200)
+
+    # generate and send EDIV and RAND using "Central Identification" ACL message
+    frame = acl(event.connection_handle, <<0x07, ediv::little-16>> <> reverse(rand))
+    BlueHeron.acl(state.ctx, frame)
+    :timer.sleep(200)
+
+    # generate and send IRK using "Identity Information" ACL message
+    frame = acl(event.connection_handle, <<0x08>> <> reverse(irk))
+    BlueHeron.acl(state.ctx, frame)
+    :timer.sleep(200)
+
+    # generate and send BD_ADDRESS using "Identity Address Information" ACL message
+    frame = acl(event.connection_handle, <<0x09, 0>> <> reverse(state.bd_address.binary()))
+    BlueHeron.acl(state.ctx, frame)
+    :timer.sleep(200)
+
+    # generate and send CSRK using "Signing Information" ACL message
+    frame = acl(event.connection_handle, <<0x0A>> <> reverse(csrk))
+    BlueHeron.acl(state.ctx, frame)
+    :timer.sleep(200)
+
+    {:reply, nil, %{state | authenticated: true}}
+  end
+
+  def handle_call({:encryption_change, _event}, _from, state) do
+    # Authenticated using exchanged long term key
+    {:reply, nil, %{state | authenticated: true}}
+  end
+
+  @doc """
+  Bluetooth LE c1() key generation function.
+
+  The function parameters can be encoded by the following example:
+
+  k is the random generated TK displayed on the device
+  r is the random number generated by the SM
+  preq is the data exchanged during pairing request
+  pres is the data exchanged during pairing response
+  iat is the initaitors device type (0x00 or 0x01)
+  rat is the receiver device type (0x00 or 0x01)
+  ia is the initaitors device address
+  ra is the receiver device address
+
+  Example from BLE specifications:
+
+  k = <<0::integer-size(128)>>
+  r = <<0x57, 0x83, 0xD5, 0x21, 0x56, 0xAD, 0x6F, 0x0E, 0x63, 0x88, 0x27, 0x4E, 0xC6, 0x70, 0x2E, 0xE0>>
+  ia = <<0xA1, 0xA2, 0xA3, 0xA4, 0xA5, 0xA6>>
+  ra = <<0xB1, 0xB2, 0xB3, 0xB4, 0xB5, 0xB6>>
+  iat = 1
+  rat = 0
+  pres = <<0x05, 0x00, 0x08, 0x00, 0x00, 0x03, 0x02>>
+  preq = <<0x07, 0x07, 0x10, 0x00, 0x00, 0x01, 0x01>>
+  <<0x1E, 0x1E, 0x3F, 0xEF, 0x87, 0x89, 0x88, 0xEA, 0xD2, 0xA7, 0x4D, 0xC5, 0xBE, 0xF1, 0x3B, 0x86>> =
+    BlueHeron.SMP.Server.c1(k, r, preq, pres, iat, rat, ia, ra)
+  """
+  def c1(k, r, preq, pres, iat, rat, ia, ra) do
+    p1 = pres <> preq <> <<rat, iat>>
+    p2 = <<0, 0, 0, 0>> <> ia <> ra
+    res = :crypto.exor(r, p1)
+    res = :crypto.crypto_one_time(:aes_128_ecb, k, res, true)
+    res = :crypto.exor(res, p2)
+    :crypto.crypto_one_time(:aes_128_ecb, k, res, true)
+  end
+
+  @doc """
+  Diversifying function d1
+  """
+  def d1(k, d, r) do
+    dx = <<0::integer-size(96), r::integer-size(16), d::integer-size(16)>>
+    :crypto.crypto_one_time(:aes_128_ecb, k, dx, true)
+  end
+
+  @doc """
+  Mask generation function dm
+  """
+  def dm(k, r) do
+    rx = <<0::integer-size(64), r::bytes>>
+
+    <<_::bytes-size(16), ret::bytes-size(16)>> =
+      :crypto.crypto_one_time(:aes_128_ecb, k, rx, true)
+
+    ret
+  end
+
+  @doc """
+  Bluetooth LE s1() key generation function.
+
+  k is the random generated TK displayed on the device
+  r1 is the random generated by the responding device
+  r2 is the random generated by the initiating device
+
+  Example from BLE specifictation:
+
+  k = <<0::integer-size(128)>>
+  r1 = Base.decode16!("000F0E0D0C0B0A091122334455667788")
+  r2 = Base.decode16!("010203040506070899AABBCCDDEEFF00")
+  "9A1FE1F0E8B0F49B5B4216AE796DA062" = Base.encode16(BlueHeron.SMP.Server.s1(k, r1, r2))
+  """
+  def s1(k, r1, r2) do
+    <<_::binary-size(8), r1::binary-size(8)>> = r1
+    <<_::binary-size(8), r2::binary-size(8)>> = r2
+    r = r1 <> r2
+    :crypto.crypto_one_time(:aes_128_ecb, k, r, true)
+  end
+
+  @doc """
+  Link key conversion function
+
+  The function h6 is used to convert keys of a given size from one key type to
+  another key type with equivalent strength.
+  The definition of the h6 function makes use of the hashing function AES-
+  CMAC W with 128-bit key W.
+
+  Exmple test vectors from Bluetooth spec:
+
+  w = Base.decode16!("EC0234A357C8AD05341010A60A397D9B")
+  key_id = Base.decode16!("6C656272")  # ASCII "lebr"
+  "2D9AE102E76DC91CE8D3A9E280B16399" = Base.encode16(BlueHeron.SMP.Server.h6(w, key_id)
+  """
+  def h6(w, key_id) do
+    :crypto.mac(:cmac, :aes_cbc, w, key_id)
+  end
+
+  defp reply_for_ltk_request(request, _ediv, nil) do
+    # EDIV does not exist, keys are "nil"
+    Logger.warn("Authentication: 'EDIV' unknown for #{request.connection_handle}")
+    LongTermKeyRequestNegativeReply.new(connection_handle: request.connection_handle)
+  end
+
+  defp reply_for_ltk_request(request, _ediv, keys) do
+    # EDIV exists, we have keys
+    <<rand::unsigned-64, ltk::bytes-size(16), _csrk::bytes-size(16), _irk::bytes-size(16)>> = keys
+
+    if rand == request.random_number do
+      LongTermKeyRequestReply.new(
+        connection_handle: request.connection_handle,
+        ltk: reverse(ltk)
+      )
+    else
+      Logger.warn("Authentication: 'Rand' missmatch on handle #{request.connection_handle}")
+      LongTermKeyRequestNegativeReply.new(connection_handle: request.connection_handle)
+    end
+  end
+
+  defp reverse(bin), do: bin |> :binary.decode_unsigned(:little) |> :binary.encode_unsigned(:big)
+
+  defp acl(handle, data) do
+    # Generate SMP related ACL response
+    %ACL{
+      handle: handle,
+      flags: %{bc: 0, pb: 0},
+      data: %L2Cap{
+        cid: 0x0006,
+        data: data
+      }
+    }
+  end
+end

--- a/lib/blue_heron/smp/keys.ex
+++ b/lib/blue_heron/smp/keys.ex
@@ -1,0 +1,59 @@
+defmodule BlueHeron.SMP.Keys do
+  use GenServer
+
+  def start(path) do
+    GenServer.start(__MODULE__, path, name: __MODULE__)
+  end
+
+  def init(path) do
+    {:ok, %{key_file: path}}
+  end
+
+  def new() do
+    GenServer.call(__MODULE__, :new)
+  end
+
+  def get(index) do
+    GenServer.call(__MODULE__, {:get, index})
+  end
+
+  def handle_call(:new, _from, state) do
+    data = read_or_create(state.key_file)
+    {index, keys} = generate_keys(data)
+    data = Map.put(data, index, keys)
+    File.write!(state.key_file, :erlang.term_to_binary(data))
+    {:reply, {index, keys}, state}
+  end
+
+  def handle_call({:get, index}, _from, state) do
+    data = read_or_create(state.key_file)
+    keys = get_keys(data, index)
+    {:reply, {index, keys}, state}
+  end
+
+  defp generate_keys(data) do
+    <<key::little-unsigned-16>> = :crypto.strong_rand_bytes(2)
+    val = :crypto.strong_rand_bytes(56)
+
+    # Make sure key (index) is unique
+    if Map.has_key?(data, key) do
+      generate_keys(data)
+    else
+      {key, val}
+    end
+  end
+
+  defp get_keys(data, index) do
+    case Map.fetch(data, index) do
+      {:ok, keys} -> keys
+      :error -> nil
+    end
+  end
+
+  defp read_or_create(file) do
+    case File.read(file) do
+      {:ok, content} -> :erlang.binary_to_term(content)
+      {:error, _reason} -> %{}
+    end
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -26,7 +26,7 @@ defmodule BlueHeron.MixProject do
 
   def application() do
     [
-      extra_applications: [:logger]
+      extra_applications: [:logger, :crypto]
     ]
   end
 


### PR DESCRIPTION
This change adds the security manager and all required HCI commands and events.

The security manager only implements LE legacy passkey pairing with the following restrictions and known issues:

 - EDIV LTK and other material from the central are not stored. Only the central can re-encrypt the connection, this is no issue as the peripheral simply replies with "encryption required" and lets the central do its job.
 - Some edge cases are not covered.

Use this change as en experimental implementation of LE legacy pairing.