### PR TITLE
read by type: Fix implementation

### DIFF
--- a/lib/blue_heron/att/responses/read_by_type_response.ex
+++ b/lib/blue_heron/att/responses/read_by_type_response.ex
@@ -1,6 +1,6 @@
 defmodule BlueHeron.ATT.ReadByTypeResponse do
   defmodule AttributeData do
-    defstruct [:handle, :characteristic_properties, :characteristic_value_handle, :uuid]
+    defstruct [:handle, :characteristic_properties, :characteristic_value_handle, :value, :uuid]
 
     def deserialize(<<handle::little-16, properties, value_handle::little-16, uuid::little-16>>) do
       %__MODULE__{
@@ -24,7 +24,8 @@ defmodule BlueHeron.ATT.ReadByTypeResponse do
           handle: handle,
           characteristic_properties: characteristic_properties,
           characteristic_value_handle: characteristic_value_handle,
-          uuid: uuid
+          uuid: uuid,
+          value: nil
         })
         when uuid < 0xFFFF do
       <<handle::little-16, characteristic_properties, characteristic_value_handle::little-16,
@@ -35,11 +36,22 @@ defmodule BlueHeron.ATT.ReadByTypeResponse do
           handle: handle,
           characteristic_properties: characteristic_properties,
           characteristic_value_handle: characteristic_value_handle,
-          uuid: uuid
+          uuid: uuid,
+          value: nil
         })
         when uuid > 0xFFFF do
       <<handle::little-16, characteristic_properties, characteristic_value_handle::little-16,
         uuid::little-128>>
+        end
+
+    def serialize(%{
+          handle: handle,
+          characteristic_properties: _characteristic_properties,
+          characteristic_value_handle: _characteristic_value_handle,
+          uuid: _uuid,
+          value: value
+        }) do
+          <<handle::little-16, value::binary>>
     end
   end
 

--- a/lib/blue_heron/gatt/server.ex
+++ b/lib/blue_heron/gatt/server.ex
@@ -457,6 +457,18 @@ defmodule BlueHeron.GATT.Server do
            error: :attribute_not_found
          }}
 
+      [characteristic] ->
+        # TODO: Handle exceptions and long values
+        value = state.mod.read(characteristic.id)
+        attr =
+          %ReadByTypeResponse.AttributeData{
+            handle: characteristic.handle,
+            uuid: characteristic.type,
+            value: value
+          }
+
+        {state, %ReadByTypeResponse{attribute_data: [attr]}}
+
       characteristics_in_range ->
         attribute_data =
           characteristics_in_range


### PR DESCRIPTION
This change fixes an issue where `ATT_READ_BY_TYPE_RSP` PDU did not contain the value of the characteristic selected. Bluetooth specification "4.8.2 Read Using Characteristic UUID" defines that the value of the characteristic is added to the PDU if only one characteristic is selected.

This issue caused empty values in the iOS device list and passkey entry form as iOS is using this method to read the devices name before characteristics are discovered.