### PR TITLE
smp: Fix key distribution list

### DIFF
--- a/lib/blue_heron/smp.ex
+++ b/lib/blue_heron/smp.ex
@@ -120,7 +120,9 @@ defmodule BlueHeron.SMP do
 
     k = <<passkey::integer-size(128)>>
     r = :crypto.strong_rand_bytes(16)
-    response = <<0x02, 0x01, 0x00, 0b00000101, 16, 0x0F, 0x0F>>
+
+    # Do not request distribute IRK or Signing Keys only EDIV, LTK
+    response = <<0x02, 0x01, 0x00, 0b00000101, 16, 0x01, 0x01>>
 
     # Set up all pairing related information
     pairing = %{
@@ -256,20 +258,22 @@ defmodule BlueHeron.SMP do
     BlueHeron.acl(state.ctx, frame)
     :timer.sleep(200)
 
+    # Note: We are only distributing LTK, EDIV and RAND, see flags set in pairing response
+
     # generate and send IRK using "Identity Information" ACL message
-    frame = acl(event.connection_handle, <<0x08>> <> reverse(irk))
-    BlueHeron.acl(state.ctx, frame)
-    :timer.sleep(200)
+    #frame = acl(event.connection_handle, <<0x08>> <> reverse(irk))
+    #BlueHeron.acl(state.ctx, frame)
+    #:timer.sleep(200)
 
     # generate and send BD_ADDRESS using "Identity Address Information" ACL message
-    frame = acl(event.connection_handle, <<0x09, 0>> <> reverse(state.bd_address.binary()))
-    BlueHeron.acl(state.ctx, frame)
-    :timer.sleep(200)
+    #frame = acl(event.connection_handle, <<0x09, 0>> <> reverse(state.bd_address.binary()))
+    #BlueHeron.acl(state.ctx, frame)
+    #:timer.sleep(200)
 
     # generate and send CSRK using "Signing Information" ACL message
-    frame = acl(event.connection_handle, <<0x0A>> <> reverse(csrk))
-    BlueHeron.acl(state.ctx, frame)
-    :timer.sleep(200)
+    #frame = acl(event.connection_handle, <<0x0A>> <> reverse(csrk))
+    #BlueHeron.acl(state.ctx, frame)
+    #:timer.sleep(200)
 
     {:reply, nil, %{state | authenticated: true}}
   end


### PR DESCRIPTION
This change removes all key distribution flags not required for the way we are using legacy pairing. iOS sent a "Pairing failed" as we promised key material we did not deliver.