### PR TITLE
peripheral: add set_scan_response_data

### DIFF
--- a/lib/blue_heron/hci/command.ex
+++ b/lib/blue_heron/hci/command.ex
@@ -32,6 +32,7 @@ defmodule BlueHeron.HCI.Command do
     LEController.SetAdvertisingParameters,
     LEController.SetRandomAddress,
     LEController.SetScanEnable,
+    LEController.SetScanResponseData,
     LEController.SetScanParameters,
     LEController.LongTermKeyRequestReply,
     LEController.LongTermKeyRequestNegativeReply,

--- a/lib/blue_heron/hci/commands/le_controller/set_advertising_data.ex
+++ b/lib/blue_heron/hci/commands/le_controller/set_advertising_data.ex
@@ -4,7 +4,8 @@ defmodule BlueHeron.HCI.Command.LEController.SetAdvertisingData do
   defparameters advertising_data: <<>>
 
   defimpl BlueHeron.HCI.Serializable do
-    def serialize(%{opcode: opcode, advertising_data: advertising_data}) do
+    def serialize(%{opcode: opcode, advertising_data: advertising_data})
+        when byte_size(advertising_data) <= 31 do
       length = byte_size(advertising_data)
       padding_size = (31 - length) * 8
 

--- a/lib/blue_heron/hci/commands/le_controller/set_scan_response_data.ex
+++ b/lib/blue_heron/hci/commands/le_controller/set_scan_response_data.ex
@@ -1,0 +1,32 @@
+defmodule BlueHeron.HCI.Command.LEController.SetScanResponseData do
+  use BlueHeron.HCI.Command.LEController, ocf: 0x0009
+
+  defparameters scan_response_data: <<>>
+
+  defimpl BlueHeron.HCI.Serializable do
+    def serialize(%{opcode: opcode, scan_response_data: scan_response_data})
+        when byte_size(scan_response_data) <= 31 do
+      length = byte_size(scan_response_data)
+      padding_size = (31 - length) * 8
+
+      <<opcode::binary, 32, length, scan_response_data::binary, 0::size(padding_size)>>
+    end
+  end
+
+  @impl BlueHeron.HCI.Command
+  def deserialize(
+        <<@opcode::binary, 32, length, scan_response_data::binary-size(length), _rest::binary>>
+      ) do
+    new(scan_response_data: scan_response_data)
+  end
+
+  @impl BlueHeron.HCI.Command
+  def deserialize_return_parameters(<<status>>) do
+    %{status: status}
+  end
+
+  @impl BlueHeron.HCI.Command
+  def serialize_return_parameters(%{status: status}) do
+    <<BlueHeron.ErrorCode.to_code!(status)>>
+  end
+end


### PR DESCRIPTION
fixes #108 

This fixes the unchecked 31 byte length of advertising_data and adds a new function to set scan response data which allows an additional 31 bytes of data to be sent when a central scans for a peripheral