### PR TITLE
fix: send advertising report to the process

### DIFF
--- a/lib/blue_heron/hci/transport.ex
+++ b/lib/blue_heron/hci/transport.ex
@@ -326,6 +326,11 @@ defmodule BlueHeron.HCI.Transport do
         for pid <- data.handlers, do: send(pid, {:HCI_EVENT_PACKET, reply})
         {:ok, reply, data}
 
+      %{code: 62, num_reports: _} = reply ->
+        # handle HCI.Event.LEMeta.AdvertisingReport
+        for pid <- data.handlers, do: send(pid, {:HCI_EVENT_PACKET, reply})
+        {:ok, reply, data}
+
       %{opcode: _opcode} = reply ->
         {:error, reply, data}
 


### PR DESCRIPTION
### [Fix] Send AdvertisingReport events to the processes

This PR introduces a fix about AdverstisingReport events that were not sent to the process as shown in the #111 issue. 

I've struggled to set up a unit test about it, so I'm open to advices 😄 .

Thanks.