### PR TITLE
Release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## v0.5.0
+
+* Enhancements
+  * `:blue_heron` is now it's own application
+  * Rewrote `BlueHeron.HCI.Transport` to support the new supervision structure
+  * Enable SMP by default
+  * Persist GATT into a `PropertyTable` to allow for better error handling
+  * Creating a Peripheral is now a little simpler and supervised
+  * Added Broadcaster role
+* Depreciations
+  * Removed `BlueHeron.Context`
+  * Removed `BlueHeronTransportUART` and `BlueHeronTransportUSB`
+
 ## v0.4.2
 
 * Bugfixes

--- a/mix.exs
+++ b/mix.exs
@@ -1,14 +1,14 @@
 defmodule BlueHeron.MixProject do
   use Mix.Project
 
-  @version "0.4.2"
+  @version "0.5.0"
   @source_url "https://github.com/blue-heron/blue_heron"
 
   def project do
     [
       app: :blue_heron,
       version: @version,
-      elixir: "~> 1.7",
+      elixir: "~> 1.18",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       description: description(),


### PR DESCRIPTION
## v0.5.0

* Enhancements
  * `:blue_heron` is now it's own application
  * Rewrote `BlueHeron.HCI.Transport` to support the new supervision structure
  * Enable SMP by default
  * Persist GATT into a `PropertyTable` to allow for better error handling
  * Creating a Peripheral is now a little simpler and supervised
  * Added Broadcaster role
* Depreciations
  * Removed `BlueHeron.Context`
  * Removed `BlueHeronTransportUART` and `BlueHeronTransportUSB`