### PR TITLE
Lossen up Elixir version requirement

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule BlueHeron.MixProject do
     [
       app: :blue_heron,
       version: @version,
-      elixir: "~> 1.18",
+      elixir: "~> 1.13.0 or ~> 1.14.0 or ~> 1.15.1 or ~> 1.16.0 or ~> 1.17.0 or ~> 1.18.0",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       description: description(),


### PR DESCRIPTION
This matches BlueHeron's Elixir requirement to match that of [Nerves](https://github.com/nerves-project/nerves/blob/a59eb469c38cc5468c6033de723227e92262469b/mix.exs#L11C1-L11C92)