### PR TITLE
v0.5.2 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.5.2
+* Enhancements
+  * Changed the Elixir version requirement to match Nerves.
+  This fixes an unneeded warning on Elixir versions older than 1.18.
+
 ## v0.5.1
 
 * Enhancements

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule BlueHeron.MixProject do
   use Mix.Project
 
-  @version "0.5.1"
+  @version "0.5.2"
   @source_url "https://github.com/blue-heron/blue_heron"
 
   def project do


### PR DESCRIPTION
## v0.5.2
* Enhancements
  * Changed the Elixir version requirement to match Nerves.
  This fixes an unneeded warning on Elixir versions older than 1.18.