### PR TITLE
Relax property_table dependency to support v0.3.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -34,7 +34,7 @@ defmodule BlueHeron.MixProject do
   defp deps() do
     [
       {:circuits_uart, "~> 1.5"},
-      {:property_table, "~> 0.2.6"},
+      {:property_table, "~> 0.3.0 or ~> 0.2.6"},
       {:ex_doc, "~> 0.35", only: :docs, runtime: false},
       {:dialyxir, "~> 1.4", only: [:dev, :test], runtime: false},
       {:credo, "~> 1.7", only: :test, runtime: false}

--- a/mix.lock
+++ b/mix.lock
@@ -13,5 +13,5 @@
   "makeup_elixir": {:hex, :makeup_elixir, "1.0.1", "e928a4f984e795e41e3abd27bfc09f51db16ab8ba1aebdba2b3a575437efafc2", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}, {:nimble_parsec, "~> 1.2.3 or ~> 1.3", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "7284900d412a3e5cfd97fdaed4f5ed389b8f2b4cb49efc0eb3bd10e2febf9507"},
   "makeup_erlang": {:hex, :makeup_erlang, "1.0.1", "c7f58c120b2b5aa5fd80d540a89fdf866ed42f1f3994e4fe189abebeab610839", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm", "8a89a1eeccc2d798d6ea15496a6e4870b75e014d1af514b1b71fa33134f57814"},
   "nimble_parsec": {:hex, :nimble_parsec, "1.4.0", "51f9b613ea62cfa97b25ccc2c1b4216e81df970acd8e16e8d1bdc58fef21370d", [:mix], [], "hexpm", "9c565862810fb383e9838c1dd2d7d2c437b3d13b267414ba6af33e50d2d1cf28"},
-  "property_table": {:hex, :property_table, "0.2.6", "41fb5e94cabc360827213abcf0b2ae255a22f834f86828df63001fccbaf3d319", [:mix], [], "hexpm", "7545a31384eb9e98da91a54cfa4ad7cb8b38ba556d6b7051c3f7d9f9f4caf567"},
+  "property_table": {:hex, :property_table, "0.3.0", "aa51e0eb5e9789edb45e1048223f7f30ffd4e4dd0e3bd4924d8fa22d7800f9f6", [:mix], [], "hexpm", "696289fe01a2d685eb460e5440e64736ec8a07d8e4748e2d573b12b590b931e3"},
 }


### PR DESCRIPTION
v0.3.0 was technically a breaking change, but not for BlueHeron's
minimal use of it. This allows both versions to be used so people can
use v0.3.0 if they want with BlueHeron.
