### PR TITLE
Update EncryptionChange deserialize/1

### DIFF
--- a/lib/blue_heron/hci/events/encryption_change.ex
+++ b/lib/blue_heron/hci/events/encryption_change.ex
@@ -33,15 +33,16 @@ defmodule BlueHeron.HCI.Event.EncryptionChange do
   end
 
   @impl BlueHeron.HCI.Event
-  def deserialize(<<@code, _size, bin::binary>>) do
-    <<
-      status,
-      lower_handle,
-      _::4,
-      upper_handle::4,
-      encryption_enabled
-    >> = bin
-
+  def deserialize(
+        <<@code, _size,
+          <<
+            status,
+            lower_handle,
+            _::4,
+            upper_handle::4,
+            encryption_enabled
+          >>::binary>>
+      ) do
     <<handle::little-12>> = <<lower_handle, upper_handle::4>>
 
     %__MODULE__{


### PR DESCRIPTION
Moving the match into the function head allows for an error tupple to propogate instead of crashing the calling process with a MatchError